### PR TITLE
feat(schools): 接入河北农业大学，教务抓取按学校适配器分发

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,11 @@ DEEPSEEK_API_KEY=
 # 设为 1 改用行内渲染器——输出顺着命令行往下滚，滚轮/选中复制可用
 # RAPTOR_TUI_INLINE=1
 
-# 南京工业大学教务系统凭证（可选）：留空则首次启动 raptor 时引导录入
+# 服务哪所学校（可选，默认 njtech）：njtech=南京工业大学 | hebau=河北农业大学
+# 一个进程只跑一所学校；换学校后请把下面的教务账号换成本校的。
+# RAPTOR_SCHOOL=hebau
+
+# 教务系统凭证（可选）：留空则首次启动 raptor 时引导录入
 # （AES-256-GCM 加密保存到本机 credentials.enc，不明文落盘）
 # JWGL_USERNAME=
 # JWGL_PASSWORD=

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,6 +12,7 @@ import { ToolLoopAgent, wrapLanguageModel } from "ai";
 import { config } from "./config";
 import { formatMemoryForPrompt } from "./memory/longterm";
 import { captureSessionPrompt, loadLastSessionTranscript } from "./memory/shortterm";
+import { activeSchool } from "./schools/registry";
 import { raptorTools } from "./tools";
 
 const deepseek = createDeepSeek({
@@ -49,7 +50,9 @@ function buildBasePrompt(enableGrab: boolean): string {
 - 盯课/抢课耗时较长（默认 60-120 秒），调用前告知用户预计耗时。`
     : "";
 
-  return `你是「迅猛龙」（CourseRaptor），南京工业大学学生的私人教务 agent。
+  const school = activeSchool();
+
+  return `你是「迅猛龙」（CourseRaptor），${school.name}学生的私人教务 agent。
 
 ## 你的能力（通过工具调用）
 
@@ -60,6 +63,8 @@ function buildBasePrompt(enableGrab: boolean): string {
 ${grabCapability}
 
 教务查询：
+- get_school_status：当前服务的学校、所在城市与已接入/未接入能力清单。任何「你能不能查××」「这所学校有什么」的问题以它为准，别凭印象答
+- submit_auth_code：提交统一认证的动态验证码（仅当某工具返回 needs_auth_code 时，向用户索要验证码后调用）
 - get_schedule：本学期课表（含节次时间段、当前周次；自动探测最新学期，也可指定如 2026-2027-1；放假/调休安排会自动叠加在对应周里）
 - set_holidays：记录放假/调休安排（读放假通知后落盘，课表自动叠加假期与调休覆盖）
 - get_grades：全部成绩 + GPA、academicSummary 学业概览（已获学分/未通过/待确认课程）及通识选修六类统计。问学分缺口或挂科时引用工具结果，不自行把未通过课程学分计入已获学分。dataComplete=false 时先说明学期数据不全；missingCategories 仅代表未覆盖，是否必修及最低学分必须核对本人培养方案，不能断言已经满足毕业要求。
@@ -93,24 +98,12 @@ ${grabCapability}
 记忆：
 - save_memory：长期记忆维护（跨会话持久的事实条目，增/删/改/查）
 
-## 背景知识（重要）
-
-- 教务系统是正方新版，选课模块为「自主选课 zzxkyzb」。
-- 教务线路偶发抖动：登录失败会自动重试（最多 5 次），若工具报「登录失败」让用户稍后再试即可。
-- 学校侧停用的模块（任何客户端都查不到）：空闲教室、班级课表、学业情况、实验课表、培养方案、站内通知。用户问这些时如实说明教务系统未开放该模块。
-
-## 校历（2026-2027 学年，2026-08-30 按官方校历核对）
-
-- 秋冬学期：注册 2026-08-29～08-30；第 1 周 2026-08-31（周一）～9-06，共 20 个教学周；本科新生报到 9-05～09-06（军训 9-14～09-30）
-- 元旦 2027-01-01；寒假 2027-01-09～02-26（春节 2027-02-06）
-- 春夏学期：注册 2027-02-27～02-28；第 1 周 2027-03-01（周一）；暑假 2027-07-10～08-27
-- 周次计算的运行时真值是 data/term-dates.json（get_schedule 返回的 week1Monday/weekNote），此处仅为背景参照，两者不一致时以工具返回为准
-- 具体哪天放假、哪天调休补课教务处临近才发通知，处理流程见行为准则第 12 条；校历原图存于 outputs/njtech-calendar-2026-2027.jpg
+${school.promptFacts}
 
 ## 行为准则
 
 1. 回答简洁直接，用中文；数据用紧凑的表格或列表呈现。
-2. 用户问「教务处最近有什么通知」「通知里具体怎么说」时，先 get_news 查列表，涉及具体时间安排（开始/截止/开学日期）再用 read_notice 读正文，不要只凭标题回答。用户直接贴出 njtech.edu.cn 的文章链接时，直接调 read_notice 读取并总结。
+2. 用户问「教务处最近有什么通知」「通知里具体怎么说」时，先 get_news 查列表，涉及具体时间安排（开始/截止/开学日期）再用 read_notice 读正文，不要只凭标题回答。用户直接贴出本校官网的文章链接时，直接调 read_notice 读取并总结。工具返回 needs_auth_code 时：向用户索要手机/邮箱收到的验证码原文，拿到后调 submit_auth_code 完成登录再重试刚才的查询，不要反复触发登录（那会一直给用户发验证码）。
 3. 查询类问题（时间/课表/成绩/考试/通知/学籍/天气）直接调用工具回答，不要反问。凡涉及时间的判断（今天几号、周几、第几周，明天/后天/下周三几号，距离某日期还有几天，通知是否已过期或临近），必须先调 get_time 拿到真实当前时间再作答，相对日期换算以它为基准——你没有可靠的时间感，凭印象推「今天」必然出错。
 4. 凭证已配置在本地 .env，不需要向用户询问学号密码。
 5. 工具返回空结果时，结合状态解释原因（未开放/假期/接口拦截），不要臆测。

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,10 @@
 
 import path from "node:path";
 import { loadCredentialsStore } from "./credentials";
-
 // 项目根目录解析独立成 paths.ts，避免与 credentials.ts 循环依赖
 import { PROJECT_ROOT as ROOT } from "./paths";
+// 学校 id 名单是叶子模块（不 import 任何适配器），否则 config 会被拖进抓取层的循环依赖
+import { normalizeSchoolId } from "./schools/ids";
 export const PROJECT_ROOT = ROOT;
 
 export type DeepSeekApiKeySource = "env" | "encrypted" | "unset";
@@ -18,6 +19,12 @@ export interface RaptorConfig {
   deepseekApiKeySource: DeepSeekApiKeySource;
   deepseekBaseUrl?: string;
   model: string;
+  /**
+   * 当前服务哪所学校（RAPTOR_SCHOOL，默认 njtech）。
+   * 单校运行是刻意的取舍：一个进程一套凭证，抓取层按这个 id 选适配器，
+   * 绝不允许「一所学校的密码被发往另一所学校的教务系统」。
+   */
+  school: string;
   jwglUsername: string;
   jwglPassword: string;
   /** 教务凭证来源（诊断用） */
@@ -82,6 +89,7 @@ function env(key: string): string | undefined {
 
 function loadConfig(): RaptorConfig {
   const stored = loadCredentialsStore();
+  const school = normalizeSchoolId(env("RAPTOR_SCHOOL"));
   const resolvedKey = resolveDeepSeekApiKey({
     environmentKey: env("DEEPSEEK_API_KEY"),
     storedKey: stored?.deepseekApiKey,
@@ -94,6 +102,7 @@ function loadConfig(): RaptorConfig {
     deepseekApiKeySource: resolvedKey.source,
     deepseekBaseUrl: env("DEEPSEEK_BASE_URL"),
     model: env("RAPTOR_MODEL") ?? "deepseek-v4-flash",
+    school,
     jwglUsername: env("JWGL_USERNAME") ?? "",
     jwglPassword: env("JWGL_PASSWORD") ?? "",
     credentialsSource: "env",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createRaptorAgent } from "./agent";
 import { config } from "./config";
 import { flushCapturedSession } from "./memory/shortterm";
 import { ensureCredentials, runDeepSeekKeySetup } from "./onboarding";
+import { activeSchool } from "./schools/registry";
 import { SLASH_COMMANDS } from "./tui/slash-menu";
 import {
   checkForUpdate,
@@ -126,7 +127,7 @@ while (running) {
           "🦖 CourseRaptor",
           updateInfo ? formatUpdateBadge(updateInfo) : null,
           config.deepseekApiKey
-            ? "NJTECH 教务 Agent（/inline 切行内模式）"
+            ? `${activeSchool().name} 教务 Agent（/inline 切行内模式）`
             : "输入无参数 /key 安全配置后即可对话",
         ]
           .filter(Boolean)
@@ -162,7 +163,7 @@ while (running) {
       title: [
         "🦖 CourseRaptor",
         updateInfo ? formatUpdateBadge(updateInfo) : null,
-        "NJTECH 教务 Agent（/card 切卡片模式）",
+        `${activeSchool().name} 教务 Agent（/card 切卡片模式）`,
       ]
         .filter(Boolean)
         .join(" · "),

--- a/src/jwgl/academics.ts
+++ b/src/jwgl/academics.ts
@@ -24,30 +24,18 @@ export function currentWeekOf(year: number, semester: number, now: Date = new Da
   return resolveCurrentWeek(year, semester, now);
 }
 
-// ── NJTECH 节次时间表 ──────────────────────────────────────────
-// 南京工业大学标准作息时间（每节课45分钟，课间休息10分钟）
-export const NJTECH_PERIOD_TIMES: Record<string, string> = {
-  "1": "08:10-08:55",
-  "2": "09:05-09:50",
-  "3": "10:20-11:05",
-  "4": "11:15-12:00",
-  "5": "14:00-14:45",
-  "6": "14:55-15:40",
-  "7": "16:00-16:45",
-  "8": "16:55-17:40",
-  "9": "19:00-19:45",
-  "10": "19:55-20:40",
-};
+// ── 节次时间表（真值在 src/schools/period-times.ts，按当前学校取）──────
+// 这里只重导出南工大那张表：历史引用方（含测试）仍从本文件拿得到，
+// 但所有「按当前学校换算」的路径都必须走 periodTimeRange()。
+export { NJTECH_PERIOD_TIMES } from "../schools/period-times";
+
+import { activePeriodTable, periodTimeRangeWith } from "../schools/period-times";
 
 export const WEEKDAY_NAMES = ["", "周一", "周二", "周三", "周四", "周五", "周六", "周日"];
 
-/** 节次号 -> 上课时间段，如 [7,8] -> "16:00-17:40" */
+/** 节次号 -> 上课时间段，如 [7,8] -> "16:00-17:40"。用当前生效学校的作息表 */
 export function periodTimeRange(periods: number[]): string | undefined {
-  if (!periods.length) return undefined;
-  const first = NJTECH_PERIOD_TIMES[String(periods[0])];
-  const last = NJTECH_PERIOD_TIMES[String(periods[periods.length - 1])];
-  if (!first || !last) return undefined;
-  return `${first.split("-")[0]}-${last.split("-")[1]}`;
+  return periodTimeRangeWith(activePeriodTable(), periods);
 }
 
 /**
@@ -221,8 +209,13 @@ export async function fetchScheduleSmart(
   };
 }
 
-/** 抓取指定单个学期的课表（kbList 为空时回退用考试数据反推） */
-async function fetchScheduleFor(
+/**
+ * 抓取指定单个学期的课表（kbList 为空时回退用考试数据反推）
+ *
+ * NJTECH 适配器的抓取原语。工具层不要直接调它——学期探测与按校分发在
+ * src/schools/probe.ts，绕过分发层就等于给别的学校发错了凭证。
+ */
+export async function fetchScheduleFor(
   cookie: string,
   year: number,
   semester: number,
@@ -393,8 +386,8 @@ export async function fetchExamsSmart(
   return { ok: true, data: { ...first, label: termLabel(first.year, first.semester), exams: [] } };
 }
 
-/** 抓取指定单个学期的考试安排 */
-async function fetchExamsFor(
+/** 抓取指定单个学期的考试安排（NJTECH 适配器原语，工具层走 probe 分发） */
+export async function fetchExamsFor(
   cookie: string,
   year: number,
   semester: number,

--- a/src/jwgl/http.ts
+++ b/src/jwgl/http.ts
@@ -84,6 +84,16 @@ async function acquireToken(): Promise<void> {
   return acquireToken();
 }
 
+/**
+ * 令牌桶对**所有**教务客户端共享，不只是本文件的 createClient。
+ * 河北农大那条链路要跨 cas.hebau.edu.cn(https) 与 urp.hebau.edu.cn:1009(http) 两台
+ * 主机攒 Cookie，塞不进这个单主机 https 客户端，只能自带传输层——但速率必须共用一个桶，
+ * 否则「多接一所学校」等于「请求速率翻倍」，礼貌边界和防 WAF 都不成立了。
+ */
+export function acquireRequestToken(): Promise<void> {
+  return acquireToken();
+}
+
 // ── 客户端 ────────────────────────────────────────────────────
 
 function parseCookieString(cookie: string): Map<string, string> {

--- a/src/jwgl/term-dates.ts
+++ b/src/jwgl/term-dates.ts
@@ -18,6 +18,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { quarantineCorruptFileSync, writeFileAtomicSync } from "../atomic-write";
+import { config } from "../config";
+// 播种表是叶子模块（只 export 数据、不 import 抓取层），不会与 config/抓取层绕成循环
+import { TERM_SEEDS } from "../schools/term-seeds";
 
 /** 来源可信度：recorded > known > estimated，只有前两者能当真值用 */
 export type TermDateSource = "recorded" | "known" | "estimated";
@@ -38,25 +41,27 @@ function dataDir(): string {
   return process.env.RAPTOR_DATA_DIR ?? path.join(PROJECT_ROOT, "data");
 }
 
-function storePath(): string {
-  return path.join(dataDir(), "term-dates.json");
+/**
+ * 按学校分文件。
+ * njtech 沿用老文件名 term-dates.json —— 存量用户实测记录过的学期一条都不丢；
+ * 第二所学校起用 term-dates.<id>.json。
+ * 分文件不是洁癖：两校的 2026 秋开学日不同（08-31 / 09-01），共用一份的话
+ * 整个学期的周次会系统性错一周，而且错得很像对的。
+ */
+function storePath(schoolId: string): string {
+  const name = schoolId === "njtech" ? "term-dates.json" : `term-dates-${schoolId}.json`;
+  return path.join(dataDir(), name);
 }
 
 /**
- * 存量学期播种值。
- * 来源说明：2025 两个学期为人工按校历校准；2026 秋依据南工教〔2026〕91号
- * 《报到注册通知》——报到 8-29～8-30、注册 8-31～9-30，第一周从 2026-08-31（周一）开始。
- * 注意这里刻意标 "known" 而非 "recorded"：有确定依据，但没有可追溯的解析链路。
+ * 各校播种值来自 src/schools/term-seeds.ts（叶子模块）。
+ * 南工大：2025 两学期人工按校历校准、2026 秋依据南工教〔2026〕91号；
+ * 河北农大：沿用 ScholarFlow 侧整理的校历表。
+ * 一律标 "known" 而非 "recorded"：有确定依据，但没有可追溯的通知解析链路。
  */
-const LEGACY_SEED: Record<string, TermStartDate> = {
-  "2025-1": { week1Monday: "2025-09-01", source: "known", evidence: "人工按校历校准" },
-  "2025-2": { week1Monday: "2026-03-02", source: "known", evidence: "人工按校历校准" },
-  "2026-1": {
-    week1Monday: "2026-08-31",
-    source: "known",
-    evidence: "南工教〔2026〕91号：报到 8-29～8-30、注册 8-31～9-30（修正此前 9-07 的估算）",
-  },
-};
+function seedFor(schoolId: string): Record<string, TermStartDate> {
+  return TERM_SEEDS[schoolId] ?? {};
+}
 
 /** 学期 key：`${学年起始年}-${1|2}` */
 export function termKey(year: number, semester: number): string {
@@ -65,30 +70,42 @@ export function termKey(year: number, semester: number): string {
 
 // ── 读写 ──────────────────────────────────────────────────────
 
-let cache: Record<string, TermStartDate> | null = null;
+/** 按学校分键缓存：同一进程内测试可以改 config.school 切校，不能读串 */
+const caches = new Map<string, Record<string, TermStartDate>>();
 
-export function loadStore(): Record<string, TermStartDate> {
-  if (cache) return cache;
+export function loadStore(schoolId: string = config.school): Record<string, TermStartDate> {
+  const hit = caches.get(schoolId);
+  if (hit) return hit;
+  let store: Record<string, TermStartDate>;
   try {
-    cache = JSON.parse(fs.readFileSync(storePath(), "utf8")) as Record<string, TermStartDate>;
+    store = JSON.parse(fs.readFileSync(storePath(schoolId), "utf8")) as Record<
+      string,
+      TermStartDate
+    >;
   } catch {
-    // 首次运行：用存量值播种并落盘，之后就以文件为准。
+    // 首次运行：用该校播种值初始化并落盘，之后就以文件为准。
     // 但如果是文件写坏了（半截 JSON），静默用种子覆盖会把已经实测记录过的学期
     // 一并冲掉——先把坏文件留个副本，别让真值无声消失。
-    quarantineCorruptFileSync(storePath());
-    cache = structuredClone(LEGACY_SEED);
-    persist(cache);
+    quarantineCorruptFileSync(storePath(schoolId));
+    store = structuredClone(seedFor(schoolId));
+    persist(store, schoolId);
   }
-  return cache;
+  caches.set(schoolId, store);
+  return store;
 }
 
-function persist(store: Record<string, TermStartDate>): void {
+function persist(store: Record<string, TermStartDate>, schoolId: string = config.school): void {
   try {
     // 原子写：这是「开学日期」的唯一真值源，写坏了整个学期的周次都会系统性算错
-    writeFileAtomicSync(storePath(), JSON.stringify(store, null, 2));
+    writeFileAtomicSync(storePath(schoolId), JSON.stringify(store, null, 2));
   } catch {
     // 只读环境（如打包后）下退化为内存存储，不影响主流程
   }
+}
+
+/** 测试用：清掉按学校分键的缓存，让改了 RAPTOR_DATA_DIR/config.school 的用例重读磁盘 */
+export function resetTermDateCache(): void {
+  caches.clear();
 }
 
 /**
@@ -102,8 +119,9 @@ export function recordWeek1Monday(
   week1Monday: string,
   source: TermDateSource,
   evidence?: string,
+  schoolId: string = config.school,
 ): TermStartDate {
-  const store = loadStore();
+  const store = loadStore(schoolId);
   const key = termKey(year, semester);
   const prev = store[key];
 
@@ -117,7 +135,7 @@ export function recordWeek1Monday(
     recordedAt: new Date().toISOString(),
   };
   store[key] = entry;
-  persist(store);
+  persist(store, schoolId);
   return entry;
 }
 
@@ -235,8 +253,12 @@ export function parseTermRef(text: string): { year: number; semester: number } |
  * 取某学期的开学日期。查不到就估算，并明确标注 estimated——
  * 调用方必须把这个标记透传出去，不能当成既定事实讲给用户。
  */
-export function resolveWeek1Monday(year: number, semester: number): TermStartDate {
-  const store = loadStore();
+export function resolveWeek1Monday(
+  year: number,
+  semester: number,
+  schoolId: string = config.school,
+): TermStartDate {
+  const store = loadStore(schoolId);
   const hit = store[termKey(year, semester)];
   if (hit) return hit;
 
@@ -255,8 +277,9 @@ export function currentWeekOf(
   year: number,
   semester: number,
   now: Date = new Date(),
+  schoolId: string = config.school,
 ): { week: number; week1Monday: string; source: TermDateSource; evidence?: string } | null {
-  const info = resolveWeek1Monday(year, semester);
+  const info = resolveWeek1Monday(year, semester, schoolId);
   const start = new Date(`${info.week1Monday}T00:00:00`).getTime();
   const week = Math.floor((now.getTime() - start) / (7 * 86400000)) + 1;
   if (week < 1 || week > 30) return null;

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -7,13 +7,41 @@ import readline from "node:readline/promises";
 
 import { config, type DeepSeekApiKeySource, maskDeepSeekApiKey } from "./config";
 import { saveCredentialsStore, saveStoredCredentials } from "./credentials";
-import { loginJwgl } from "./jwgl/auth";
+import { activeSchool } from "./schools/registry";
+import type { SchoolAdapter, SchoolSession } from "./schools/types";
 import { createMutedTerminalOutput } from "./secret-input";
+import { secondFactorGate } from "./tools/session";
+
+/**
+ * 引导期的登录。需要二次认证的学校（如河农大 CAS）在这里当场用终端收验证码：
+ * 用户跳过或码错就抛错，绝不把「没验证过的账号」存进 credentials.enc——
+ * 那会让下次启动直接带着无效凭证跑，报错还看不出根因。
+ */
+async function loginWithOptionalSecondFactor(
+  school: SchoolAdapter,
+  username: string,
+  password: string,
+  rl: readline.Interface,
+): Promise<SchoolSession> {
+  try {
+    return await school.login({ username, password });
+  } catch (e) {
+    const gate = secondFactorGate(e);
+    if (!gate) throw e;
+    console.log(`\n   ${gate.error}`);
+    const code = (await rl.question("验证码（直接回车跳过）: ")).trim();
+    if (!code) {
+      throw new Error("未提供验证码，本次没有完成登录验证，账号未保存");
+    }
+    return school.login({ username, password, challengeId: gate.challenge_id, dynamicCode: code });
+  }
+}
 
 export async function ensureCredentials(): Promise<void> {
   if (config.jwglUsername && config.jwglPassword) return;
 
-  console.log("🦖 首次使用：第 1 步，共 2 步——配置教务系统账号");
+  const school = activeSchool();
+  console.log(`🦖 首次使用：第 1 步，共 2 步——配置${school.name}教务系统账号`);
   console.log("   账号和密码将 AES-256-GCM 加密保存在本机，不会明文落盘。\n");
   const out = createMutedTerminalOutput();
   // terminal: true 不能省：output 是自定义 Writable（没有 isTTY），省了它
@@ -48,7 +76,7 @@ export async function ensureCredentials(): Promise<void> {
 
       try {
         // 真实登录验证：密码错误当场重输，避免存入无效凭证
-        await loginJwgl(username, password);
+        await loginWithOptionalSecondFactor(school, username, password, rl);
         saveStoredCredentials(username, password);
         config.jwglUsername = username;
         config.jwglPassword = password;

--- a/src/schools/hebau/cas.ts
+++ b/src/schools/hebau/cas.ts
@@ -1,0 +1,255 @@
+/**
+ * 河北农大 CAS 统一认证（cas.hebau.edu.cn/authserver）
+ *
+ * 登录链（每一步都是 ScholarFlow 在生产里踩出来的，顺序不能调）：
+ *   1. GET  登录页 → 取 execution 与 pwdEncryptSalt
+ *   2. POST 登录   → 密码按站点 encrypt.js 的口径做 AES-CBC（64 位随机前缀 + 明文）
+ *   3. 可能命中 /reAuthCheck/ → 发动态码，存待验证会话，抛 SecondFactorRequiredError
+ *   4. 拿 Cookie 回访 CAS → 302 链落到 URP，取出 GS_SESSIONID
+ *
+ * 为什么手写而不是 fetch：跨主机 302 链上要一路攒 Cookie（CAS 的 TGT 与 URP 的
+ * GS_SESSIONID 不同主机），fetch 的自动重定向会把 Set-Cookie 吞在内部拿不到。
+ */
+
+import crypto from "node:crypto";
+import {
+  beginSecondFactor,
+  clearSecondFactor,
+  readSecondFactor,
+  SecondFactorRequiredError,
+} from "../mfa";
+import type { SchoolLoginInput, SchoolSession } from "../types";
+import { CAS_BASE, CookieJar, type RawResponse, requestWithJar, URP_HOME } from "./http";
+
+/** 站点 encrypt.js 的随机串字符集（去掉了 0/O/1/l 等易混字符） */
+const AES_CHARS = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
+
+function randStr(n: number): string {
+  let s = "";
+  for (let i = 0; i < n; i++) s += AES_CHARS[Math.floor(Math.random() * AES_CHARS.length)];
+  return s;
+}
+
+/**
+ * 复刻官网 encrypt.js：明文 = 64 位随机前缀 + 原密码，key = salt 的 UTF-8 字节，
+ * iv = 16 位随机字节的 UTF-8，输出只有密文 base64（iv 不随密文一起送）。
+ *
+ * 密钥长度决定 AES 位数（CryptoJS 按字节数自选 128/192/256）。长度不是这三种时
+ * 直接失败——宁可报「登录参数异常」，也不能悄悄用错的 key 加密出去，
+ * 那会被 CAS 判成密码错误，用户只会以为自己的密码不对。
+ */
+export function encryptPassword(password: string, salt: string): string {
+  const plain = `${randStr(64)}${password}`;
+  const key = Buffer.from(salt.trim(), "utf8");
+  const iv = Buffer.from(randStr(16), "utf8");
+  const algorithm: Record<number, string> = {
+    16: "aes-128-cbc",
+    24: "aes-192-cbc",
+    32: "aes-256-cbc",
+  };
+  const cipherName = algorithm[key.length];
+  if (!cipherName) {
+    throw new Error(
+      `河北农大登录加密参数异常（pwdEncryptSalt 长度 ${key.length} 字节），未提交登录`,
+    );
+  }
+  const cipher = crypto.createCipheriv(cipherName, key, iv);
+  cipher.setAutoPadding(true);
+  return Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]).toString("base64");
+}
+
+/** reAuthType → 发码接口要的字段名。映射表外的一律视为不支持，不猜 */
+const REAUTH_TYPE_TO_CODE_FIELD: Record<string, string> = {
+  "3": "reAuthDynamicCodeType",
+  "4": "reAuthWChatDynamicCodeType",
+  "5": "reAuthCpdailyDynamicCodeType",
+  "11": "reAuthEmailDynamicCodeType",
+  "12": "reAuthDingTalkDynamicCodeType",
+  "13": "reAuthWeLinkDynamicCodeType",
+};
+
+const REAUTH_TYPE_LABEL: Record<string, string> = {
+  "3": "手机短信",
+  "4": "微信",
+  "5": "企业微信",
+  "11": "邮箱",
+  "12": "钉钉",
+  "13": "WeLink",
+};
+
+function extractJsonString(html: string, key: string): string {
+  return html.match(new RegExp(`"${key}":"([^"]*)"`, "i"))?.[1] ?? "";
+}
+
+/** 页面里的投递目标是「138****1234」这种带括号的脱敏串 */
+function extractMaskedTarget(html: string): string {
+  return html.match(/value="[^"]*\(([^)]+)\)"/)?.[1] ?? "";
+}
+
+function parseJson<T>(body: string): T | null {
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** 登录成功判据：URP 的 GS_SESSIONID。拿不到就如实报，不要带着空 Cookie 去请求数据接口 */
+async function finalizeUrpSession(jar: CookieJar): Promise<string> {
+  await requestWithJar(`${CAS_BASE}/authserver/login?service=${encodeURIComponent(URP_HOME)}`, jar);
+  const session = jar.get("GS_SESSIONID") ?? "";
+  if (!session)
+    throw new Error("河北农大认证已通过，但未拿到教务系统会话（GS_SESSIONID），请稍后重试");
+  return jar.header();
+}
+
+export async function loginHebau(input: SchoolLoginInput): Promise<SchoolSession> {
+  const username = (input.username ?? "").trim();
+  const password = input.password ?? "";
+  if (!username || !password) throw new Error("请输入学号和密码");
+
+  if (input.challengeId && input.dynamicCode) {
+    return completeSecondFactor(input.challengeId, input.dynamicCode, username);
+  }
+
+  const jar = new CookieJar();
+  const loginUrl = `${CAS_BASE}/authserver/login?service=${encodeURIComponent(URP_HOME)}`;
+  const page = await requestWithJar(loginUrl, jar);
+  const execution = page.body.match(/name="execution"\s+value="([^"]*)"/)?.[1] ?? "";
+  const salt = page.body.match(/id="pwdEncryptSalt"\s+value="([^"]*)"/)?.[1] ?? "";
+  if (!execution) throw new Error("无法获取河北农大统一认证登录参数（execution 缺失）");
+
+  const body = new URLSearchParams({
+    username,
+    passwordText: password,
+    password: salt ? encryptPassword(password, salt) : password,
+    execution,
+    _eventId: "submit",
+    lt: "",
+    cllt: "userNameLogin",
+    dllt: "generalLogin",
+    rememberMe: "true",
+    service: URP_HOME,
+  }).toString();
+
+  // 这一步必须禁止自动重定向：Location 指向 reAuthCheck 还是 URP，决定了后面走哪条路
+  const loginResp = await requestWithJar(loginUrl, jar, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+    followRedirects: false,
+  });
+
+  // 认证失败时 CAS 原样回吐登录页（页面里必然有 pwdEncryptSalt）
+  if (loginResp.body.includes("pwdEncryptSalt")) {
+    throw new Error("学号或密码不正确");
+  }
+
+  const location = typeof loginResp.headers.location === "string" ? loginResp.headers.location : "";
+  if (location.includes("/reAuthCheck/")) {
+    throw await beginDynamicCodeChallenge(location, jar, username, loginResp);
+  }
+
+  // 认证成功：先把 CAS→URP 这一段跳转跟完（票据在这一跳落地），再取 GS_SESSIONID
+  if (location) {
+    await requestWithJar(new URL(location, CAS_BASE).toString(), jar);
+  }
+
+  const cookie = await finalizeUrpSession(jar);
+  return { cookie, username };
+}
+
+/** 触发二次认证：发码 → 落盘待验证会话 → 抛出让对话层去要验证码 */
+async function beginDynamicCodeChallenge(
+  reAuthUrl: string,
+  jar: CookieJar,
+  username: string,
+  loginResp: RawResponse,
+): Promise<Error> {
+  const target = new URL(reAuthUrl, CAS_BASE).toString();
+  const check = await requestWithJar(target, jar);
+  const html = check.body || loginResp.body;
+  const reAuthType = extractJsonString(html, "reAuthType");
+  const isMultifactor = extractJsonString(html, "isMultifactor") || "true";
+  const maskedTarget = extractMaskedTarget(html);
+  const authCodeTypeName = REAUTH_TYPE_TO_CODE_FIELD[reAuthType];
+  if (!authCodeTypeName) {
+    return new Error(
+      `河北农大要求暂不支持的二次认证方式（reAuthType=${reAuthType || "未知"}），请到统一认证平台手动完成一次登录后再试`,
+    );
+  }
+
+  const send = await requestWithJar(
+    `${CAS_BASE}/authserver/dynamicCode/getDynamicCodeByReauth.do`,
+    jar,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest",
+        Referer: target,
+      },
+      body: new URLSearchParams({ userName: username, authCodeTypeName }).toString(),
+    },
+  );
+  const sent = parseJson<{ res?: string; returnMessage?: string }>(send.body);
+  const ok = ["success", "wechat_success", "cpdaily_success"].includes(sent?.res ?? "");
+  if (!ok) {
+    return new Error(
+      `河北农大验证码发送失败：${sent?.returnMessage || send.body.slice(0, 80) || "接口无响应"}`,
+    );
+  }
+
+  const challengeId = beginSecondFactor({
+    schoolId: "hebau",
+    username,
+    reAuthType,
+    isMultifactor,
+    maskedTarget: `${maskedTarget ? `${maskedTarget}（${REAUTH_TYPE_LABEL[reAuthType]}）` : REAUTH_TYPE_LABEL[reAuthType]}`,
+    cookies: jar.entries(),
+    serviceUrl: URP_HOME,
+  });
+  return new SecondFactorRequiredError(
+    challengeId,
+    maskedTarget
+      ? `${maskedTarget}（${REAUTH_TYPE_LABEL[reAuthType]}）`
+      : REAUTH_TYPE_LABEL[reAuthType],
+  );
+}
+
+/** 用验证码续完登录 */
+export async function completeSecondFactor(
+  challengeId: string,
+  dynamicCode: string,
+  username: string,
+): Promise<SchoolSession> {
+  const pending = readSecondFactor(challengeId, "hebau", username);
+  if (typeof pending === "string") throw new Error(pending);
+
+  const jar = new CookieJar(pending.cookies);
+  const submit = await requestWithJar(`${CAS_BASE}/authserver/reAuthCheck/reAuthSubmit.do`, jar, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      "X-Requested-With": "XMLHttpRequest",
+      Referer: `${CAS_BASE}/authserver/reAuthCheck/reAuthLoginView.do?isMultifactor=true&service=${encodeURIComponent(pending.serviceUrl)}`,
+    },
+    body: new URLSearchParams({
+      service: pending.serviceUrl,
+      reAuthType: pending.reAuthType,
+      isMultifactor: pending.isMultifactor,
+      dynamicCode,
+      skipTmpReAuth: "false",
+    }).toString(),
+  });
+  const result = parseJson<{ code?: string; msg?: string }>(submit.body);
+  if (result?.code !== "reAuth_success") {
+    // 码错但会话还新：留着，用户重发一次对话就能再试，不必重新走一遍登录
+    throw new Error(
+      `验证码校验失败：${result?.msg || "未知原因"}。验证码会话仍在有效期内，可再试一次；连续错三次请重新查询以获取新验证码`,
+    );
+  }
+  const cookie = await finalizeUrpSession(jar);
+  clearSecondFactor(challengeId);
+  return { cookie, username: pending.username };
+}

--- a/src/schools/hebau/exams.ts
+++ b/src/schools/hebau/exams.ts
@@ -1,0 +1,124 @@
+/**
+ * 河北农大考试安排
+ *
+ * URP 的 wdks 接口把已排考场与未排考场分在 arranged / notArranged 两个桶里，
+ * 两个桶都是「本人的考试」，只是前者有教室时间、后者还没排。
+ * 合并返回，未排的行保留空 location/time —— 模型据此能说「还没排考场」，
+ * 而不是把没排的那几门直接漏掉（漏了就是「你只有 3 门考试」这种错话）。
+ */
+
+import type { FetchResult } from "../../jwgl/http";
+import type { ExamData } from "../../jwgl/types";
+import { extractUrpRows, pickString, urpPostExams, xnxqdm } from "./urp";
+
+/** KSSJ 常见形态：「上午 08:00-10:00」「08:00-10:00」「第1-2节」；Display 字段里再抠时间 */
+export function parseExamTime(row: Record<string, unknown>): string {
+  const direct = pickString(row, ["KSSJ", "kssj", "SJKSSJ", "sjkssj"]);
+  // 日期与时间同串（「2026-06-20 08:00-10:00」）时只取时间部分：日期已由
+  // parseExamDate 拆给 date，整串塞进 time 会让模型把日期当时间播报。
+  const clock = direct.match(/\d{1,2}:\d{2}(?:\s*-\s*\d{1,2}:\d{2})?/);
+  if (clock) return clock[0].replace(/\s*-\s*/g, "-");
+  if (direct && !/^\d{4}[-/]/.test(direct)) return direct;
+  const display = pickString(row, [
+    "KSSJ_DISPLAY",
+    "kssj_display",
+    "SJKSSJ_DISPLAY",
+    "sjkssj_display",
+  ]);
+  const matched = display.match(/\d{2}:\d{2}(?:-\d{2}:\d{2})?/);
+  if (matched) return matched[0];
+  return direct || "";
+}
+
+/** 考试日期。有些接口把日期与时间塞在同一个 KSSJ 里（「2026-06-15 08:00-10:00」） */
+export function parseExamDate(row: Record<string, unknown>): string {
+  const date = pickString(row, ["KSRQ", "ksrq", "SJKSRQ", "sjksrq"]);
+  // 统一成 YYYY-MM-DD：URP 有以斜杠分隔的形态，留着斜杠下游按日期排序会比较错
+  if (date) return date.split(/\s+/)[0].replace(/\//g, "-");
+  const merged = pickString(row, [
+    "KSSJ",
+    "kssj",
+    "SJKSSJ",
+    "sjkssj",
+    "KSSJ_DISPLAY",
+    "kssj_display",
+  ]);
+  return merged.match(/\d{4}[-/]\d{1,2}[-/]\d{1,2}/)?.[0]?.replace(/\//g, "-") ?? "";
+}
+
+export function toExamRow(row: Record<string, unknown>): ExamData | null {
+  const subject = pickString(row, ["KCMC", "kcmc", "KCM", "kcm", "XSKCM", "xskcm"]);
+  const date = parseExamDate(row);
+  // 科目与日期两者都缺就无法定位到一场考试（纯备注行），丢；
+  // 只缺 date 的行是「已报名未排期」，保留，交给工具层如实说明
+  if (!subject || (!date && !pickString(row, ["KSJC", "ksjc"]))) return null;
+  const notes = pickString(row, [
+    "KSDM_DISPLAY",
+    "ksdm_display",
+    "PKSM",
+    "pksm",
+    "KSSM",
+    "kssm",
+    "BZ",
+    "bz",
+  ]);
+  return {
+    subject,
+    date,
+    time: parseExamTime(row) || pickString(row, ["KSJC", "ksjc", "KSSJC", "kssjc"]),
+    location: pickString(row, [
+      "CDMC",
+      "cdmc",
+      "JASMC",
+      "jasmc",
+      "JSMC",
+      "jsmc",
+      "CDMC_DISPLAY",
+      "cdmc_display",
+      "JASDM_DISPLAY",
+      "jasdm_display",
+      "JXLDM_DISPLAY",
+      "jxldm_display",
+    ]),
+    seatNumber: pickString(row, ["ZWH", "zwh", "KSWHH", "kswih"]),
+    ...(notes ? { notes } : {}),
+  };
+}
+
+/** 去重：同一门课在 arranged/notArranged 或分页里重复出现时只留信息更全的那条 */
+export function dedupeExams(rows: ExamData[]): ExamData[] {
+  const best = new Map<string, ExamData>();
+  for (const row of rows) {
+    const key = `${row.subject}|${row.date}|${row.time}`;
+    const prev = best.get(key);
+    if (!prev) {
+      best.set(key, row);
+      continue;
+    }
+    const score = (e: ExamData) => (e.location ? 2 : 0) + (e.seatNumber ? 1 : 0);
+    if (score(row) > score(prev)) best.set(key, row);
+  }
+  return [...best.values()].sort((a, b) => (a.date || "9999").localeCompare(b.date || "9999"));
+}
+
+export async function fetchHebauExams(
+  cookie: string,
+  year: number,
+  semester: number,
+): Promise<FetchResult<ExamData[]>> {
+  const xnxqdmValue = xnxqdm(year, semester);
+  const action = `获取${xnxqdmValue}考试安排`;
+  const resp = await urpPostExams(
+    cookie,
+    new URLSearchParams({ XNXQDM: xnxqdmValue }).toString(),
+    action,
+  );
+  if (!resp.ok) return resp;
+
+  const rows = extractUrpRows(resp.data, "queryMyExamArrangeMent");
+  if (!rows) {
+    return { ok: false, error: `${action}失败：教务系统响应结构异常（找不到考试数据行）` };
+  }
+  const exams = rows.map(toExamRow).filter((e): e is ExamData => e !== null);
+  return { ok: true, data: dedupeExams(exams) };
+}

--- a/src/schools/hebau/grades.ts
+++ b/src/schools/hebau/grades.ts
@@ -1,0 +1,237 @@
+/**
+ * 河北农大成绩与 GPA（5.0 满绩制）
+ *
+ * 与 ScholarFlow 侧那套的两处口径差异，都是刻意改的：
+ * 1. 「合格/通过/免修/免考」在这里是 **null（不参与 GPA）**，ScholarFlow 记 3.5 计入分母。
+ *    军训、劳动、毕业实习这类课只给「合格」，按 3.5 计入会把 GPA 往上抬；
+ *    按 0 计入又会往下拽。唯一正确的处理是整体移出分子分母，另记 passFailCredits。
+ * 2. 缓考/缺考/空值也返回 null，而不是 ScholarFlow 那样的 0——
+ *    把「还没考」当成「考了 0 分」是实打实的数据错误。
+ *
+ * 抓取侧沿用 courseraptor 的硬约定：单学期查询失败要重试，重试仍失败要进 failedTerms
+ * 报给模型（静默丢一学期会让「你没有挂科」这类结论整个失效）。
+ */
+
+import type { GradeCourse, GradeResult } from "../../jwgl/types";
+import { extractUrpRows, pickString, urpPostGrades } from "./urp";
+
+/** 通过型成绩：有学分、不计绩点 */
+export function isHebauPassFail(score: string): boolean {
+  const t = String(score || "").trim();
+  return ["合格", "通过", "免修", "免考"].includes(t);
+}
+
+const GRADE_POINTS: Record<string, number> = {
+  优秀: 4.5,
+  良好: 3.5,
+  中等: 2.5,
+  及格: 1.5,
+  不及格: 0,
+  不合格: 0,
+  未通过: 0,
+  不通过: 0,
+};
+
+/**
+ * 河北农大绩点：百分制 = 分数/10 - 5（60 分 → 1.0，100 分 → 5.0）。
+ * 返回 null 表示该成绩不参与 GPA（通过型/缓考/缺考/空），与 0（参与、绩点为 0）是两回事。
+ */
+export function hebauGradeToGP(score: string): number | null {
+  const raw = String(score ?? "").trim();
+  if (!raw) return null;
+  if (/^\d+(?:\.\d+)?$/.test(raw)) {
+    const n = Number(raw);
+    if (n > 100) return null;
+    return n < 60 ? 0 : Math.round((n / 10 - 5) * 10) / 10;
+  }
+  if (raw in GRADE_POINTS) return GRADE_POINTS[raw];
+  if (isHebauPassFail(raw)) return null;
+  // 缓考/缺考/取消成绩等标记：不猜，移出计算，让上层如实报「待确认」
+  return null;
+}
+
+/** 必修判定。URP 的 KCXZDM 给代码（001），也有直接给中文名的形态 */
+export function isHebauRequired(type: string): boolean {
+  const t = String(type || "").trim();
+  return t === "001" || t === "必修" || t.includes("必修");
+}
+
+/** 课程性质代码 → 可读文本（001 必修 / 002 选修 这类，未知代码原样返回） */
+export function normalizeCourseType(row: Record<string, unknown>): string {
+  const display = pickString(row, ["KCXZDM_DISPLAY", "kcxzdm_display", "KCXZMC", "kcxzmc"]);
+  if (display) return display;
+  const code = pickString(row, ["KCXZDM", "kcxzdm", "KCXZ", "kcxz"]);
+  const known: Record<string, string> = {
+    "001": "必修",
+    "002": "选修",
+    "003": "选修",
+    "004": "选修",
+  };
+  return known[code] ?? (code || "选修");
+}
+
+/** 从学号前四位推入学年份；不规范时往前多查几年（漏学期比多几个空学期严重） */
+export function enrollYearFromStudentId(username: string, now = new Date().getFullYear()): number {
+  const y = Number.parseInt((username || "").slice(0, 4), 10);
+  if (Number.isFinite(y) && y >= 2000 && y <= now) return y;
+  return now - 5;
+}
+
+/** 单行成绩 → GradeCourse。课程名为空的行（统计行、合计行）丢弃 */
+export function toGradeRow(row: Record<string, unknown>, semester: string): GradeCourse | null {
+  const course = pickString(row, ["KCMC", "kcmc", "XSKCM", "xskcm", "KCM", "kcm"]);
+  if (!course) return null;
+  return {
+    course,
+    courseCode: pickString(row, ["KCH", "kch", "KCDM", "kcdm"]),
+    score: pickString(row, ["ZCJ", "zcj", "CJ", "cj", "BFZCJ", "bfzcj"]) || "0",
+    credit: pickString(row, ["XF", "xf", "JXZHXF", "jxzhxf"]) || "0",
+    type: normalizeCourseType(row),
+    semester: pickString(row, ["XNXQDM", "xnxqdm"]) || semester,
+  };
+}
+
+/** 重修去重：键 = 课程号 + 课程性质。只按课程名去重会吞掉跨学期同名课的学分 */
+export function dedupeGrades(courses: GradeCourse[]): GradeCourse[] {
+  const best = new Map<string, GradeCourse>();
+  for (const course of courses) {
+    const key = `${course.courseCode || course.course}|${course.type || ""}`;
+    const prev = best.get(key);
+    if (!prev || numericScore(course.score) > numericScore(prev.score)) best.set(key, course);
+  }
+  return [...best.values()];
+}
+
+/** 仅用于重修比较的数值化：等级制折算成分段，未知标记排在所有有效成绩之后 */
+function numericScore(score: string): number {
+  const raw = String(score || "").trim();
+  if (/^\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
+  const map: Record<string, number> = {
+    优秀: 90,
+    良好: 80,
+    中等: 70,
+    及格: 60,
+    合格: 60,
+    通过: 60,
+  };
+  return map[raw] ?? -1;
+}
+
+function querySetting(semesterCode: string): string {
+  return JSON.stringify([
+    { name: "XNXQDM", value: semesterCode, linkOpt: "and", builder: "m_value_equal" },
+    {
+      name: "SFYX",
+      caption: "是否有效",
+      linkOpt: "AND",
+      builder: "m_value_equal",
+      value: "1",
+      value_display: "是",
+    },
+    {
+      name: "SHOWMAXCJ",
+      caption: "显示最高成绩",
+      linkOpt: "AND",
+      builder: "m_value_equal",
+      value: "0",
+      value_display: "否",
+    },
+  ]);
+}
+
+/** 抓一个学期的全部成绩（分页拿全，单学期失败重试 3 次后报 failedTerms） */
+async function fetchTermGrades(
+  cookie: string,
+  semesterCode: string,
+): Promise<GradeCourse[] | null> {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const page = await fetchGradePage(cookie, semesterCode, 1);
+    if (!page.ok) {
+      if (attempt === 3) return null;
+      await new Promise((r) => setTimeout(r, attempt * 1500));
+      continue;
+    }
+    const rows = page.rows
+      .map((row) => toGradeRow(row, semesterCode))
+      .filter((g): g is GradeCourse => g !== null);
+    // 正方用 limit 分页：返回条数等于页大小就说明后面还有
+    if (rows.length < page.pageSize) return rows;
+    const rest: GradeCourse[] = rows;
+    let pageNumber = 2;
+    while (pageNumber <= 20) {
+      const next = await fetchGradePage(cookie, semesterCode, pageNumber);
+      if (!next.ok) break;
+      const more = next.rows
+        .map((row) => toGradeRow(row, semesterCode))
+        .filter((g): g is GradeCourse => g !== null);
+      rest.push(...more);
+      if (more.length < next.pageSize) break;
+      pageNumber++;
+    }
+    return rest;
+  }
+  return null;
+}
+
+async function fetchGradePage(
+  cookie: string,
+  semesterCode: string,
+  pageNumber: number,
+): Promise<
+  { ok: true; rows: Record<string, unknown>[]; pageSize: number } | { ok: false; error: string }
+> {
+  const pageSize = 100;
+  const body = `querySetting=${encodeURIComponent(querySetting(semesterCode))}&*order=-XNXQDM,-KCH,-KXH&pageSize=${pageSize}&pageNumber=${pageNumber}&pageNum=${pageSize}&isAjax=true&sort=`;
+  const resp = await urpPostGrades(cookie, body, `获取${semesterCode}成绩`);
+  if (!resp.ok) return { ok: false, error: resp.error };
+  const rows = extractUrpRows(resp.data, "xscjcx");
+  if (!rows) return { ok: false, error: `获取${semesterCode}成绩失败：教务系统响应结构异常` };
+  return { ok: true, rows, pageSize };
+}
+
+/** 抓全部学期成绩并算 GPA（5.0 制，仅必修计入） */
+export async function fetchHebauGrades(cookie: string, username: string): Promise<GradeResult> {
+  const all: GradeCourse[] = [];
+  const failedTerms: string[] = [];
+  const nowYear = new Date().getFullYear();
+  const fromYear = enrollYearFromStudentId(username, nowYear);
+
+  for (let y = Math.max(2000, fromYear); y <= nowYear; y++) {
+    for (const term of ["1", "2"] as const) {
+      const code = `${y}-${y + 1}-${term}`;
+      const rows = await fetchTermGrades(cookie, code);
+      if (rows) all.push(...rows);
+      else failedTerms.push(`${code}：查询失败（已重试 3 次）`);
+    }
+  }
+
+  const deduped = dedupeGrades(all);
+  const required = deduped.filter((g) => isHebauRequired(g.type) && Number(g.credit) > 0);
+  const scored = required.filter((g) => hebauGradeToGP(g.score) !== null);
+  const excluded = required.length - scored.length;
+
+  let gpSum = 0;
+  let creditSum = 0;
+  for (const g of scored) {
+    const credit = Number(g.credit) || 0;
+    gpSum += (hebauGradeToGP(g.score) as number) * credit;
+    creditSum += credit;
+  }
+
+  return {
+    gpa: creditSum > 0 ? (gpSum / creditSum).toFixed(2) : "0.00",
+    requiredCredits: Math.round(creditSum * 100) / 100,
+    requiredCourses: required.length,
+    gpaBasis:
+      `河北农大 5.0 满绩制（百分制折算：分数/10-5；优秀 4.5、良好 3.5、中等 2.5、及格 1.5）；` +
+      `仅必修课计入，已排除 ${excluded} 门通过型/无绩点课程（合格、免修、缓考等不计 GPA）`,
+    passFailCredits:
+      Math.round(
+        required
+          .filter((g) => isHebauPassFail(g.score))
+          .reduce((sum, g) => sum + (Number(g.credit) || 0), 0) * 100,
+      ) / 100,
+    allCourses: deduped,
+    failedTerms,
+  };
+}

--- a/src/schools/hebau/http.ts
+++ b/src/schools/hebau/http.ts
@@ -1,0 +1,197 @@
+/**
+ * 河北农大 HTTP 传输层（CAS 与 URP 共用）
+ *
+ * 为什么不复用 src/jwgl/http.ts 的 createClient：
+ * 那个客户端写死 https、写死正方 jwgl 的 Cookie/Referer 语义，而河北农大是
+ * 「http://urp.hebau.edu.cn:1009 + https://cas.hebau.edu.cn」两段式跨主机跳转，
+ * 重定向链上必须一路攒 Cookie（CAS 的 TGT、URP 的 GS_SESSIONID 分属不同主机）。
+ * 硬塞进单主机客户端会把两边的语义都改脏，所以单独一个薄客户端。
+ *
+ * 唯一必须共享的是节流令牌桶：礼貌边界和防 WAF 是进程级的，
+ * 多开一个客户端不该多出一倍速率，所以从 jwgl/http 借用同一个桶。
+ */
+
+import http from "node:http";
+import https from "node:https";
+import { acquireRequestToken } from "../../jwgl/http";
+
+export const CAS_BASE = "https://cas.hebau.edu.cn";
+export const URP_BASE = "http://urp.hebau.edu.cn:1009";
+export const URP_HOME = `${URP_BASE}/jwapp/sys/homeapp/index.do`;
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REDIRECTS = 8;
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+
+export interface RawResponse {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+export interface RequestOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+/** 传输函数。单测靠它注入假响应，不去打真实教务系统 */
+export type Transport = (url: string, opts: RequestOptions) => Promise<RawResponse>;
+
+let transport: Transport = nodeTransport;
+
+/** 仅供测试注入。传 null 恢复真实实现 */
+export function setTransportForTest(fn: Transport | null): void {
+  transport = fn ?? nodeTransport;
+}
+
+function nodeTransport(url: string, opts: RequestOptions): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const lib = u.protocol === "https:" ? https : http;
+    const req = lib.request(
+      {
+        hostname: u.hostname,
+        port: u.port || (u.protocol === "https:" ? 443 : 80),
+        path: u.pathname + u.search,
+        method: opts.method ?? "GET",
+        headers: {
+          "User-Agent": USER_AGENT,
+          Accept: "text/html,application/xhtml+xml,application/json,text/javascript,*/*;q=0.8",
+          "Accept-Language": "zh-CN,zh;q=0.9",
+          ...opts.headers,
+        },
+      },
+      (res) => {
+        // 逐块 toString 会切断跨块的 UTF-8 中文（课程名/教师名全中文），先攒 Buffer
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers as Record<string, string | string[] | undefined>,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    req.on("error", (e) => reject(new Error(`网络错误：${e.message}`)));
+    req.setTimeout(REQUEST_TIMEOUT_MS, () =>
+      req.destroy(new Error(`请求超时（${REQUEST_TIMEOUT_MS}ms）`)),
+    );
+    if (opts.body) req.write(opts.body);
+    req.end();
+  });
+}
+
+// ── Cookie jar ────────────────────────────────────────────────
+
+export class CookieJar {
+  private map = new Map<string, string>();
+
+  constructor(initial?: [string, string][]) {
+    if (initial) this.map = new Map(initial);
+  }
+
+  /** 从 "k=v; k2=v2" 形式的 Cookie 头还原（登录产出的会话串走这条路径回装） */
+  static fromHeader(cookie: string): CookieJar {
+    const jar = new CookieJar();
+    for (const part of (cookie || "").split(";")) {
+      const eq = part.indexOf("=");
+      if (eq > 0) jar.set(part.slice(0, eq).trim(), part.slice(eq + 1).trim());
+    }
+    return jar;
+  }
+
+  /** 从 Set-Cookie 头吸收（只取 name=value，丢掉 Path/Expires 等属性） */
+  absorb(header: string | string[] | undefined): void {
+    if (!header) return;
+    for (const line of Array.isArray(header) ? header : [header]) {
+      const kv = line.split(";")[0];
+      const eq = kv.indexOf("=");
+      if (eq > 0) this.map.set(kv.slice(0, eq).trim(), kv.slice(eq + 1).trim());
+    }
+  }
+
+  set(name: string, value: string): void {
+    this.map.set(name, value);
+  }
+
+  get(name: string): string | undefined {
+    return this.map.get(name);
+  }
+
+  entries(): [string, string][] {
+    return [...this.map.entries()];
+  }
+
+  header(): string {
+    return [...this.map.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+  }
+
+  get isEmpty(): boolean {
+    return this.map.size === 0;
+  }
+}
+
+// ── 带 Cookie 与手动重定向的请求 ──────────────────────────────
+
+export interface SessionRequestOptions extends RequestOptions {
+  /** 默认跟随重定向（CAS 登录链全靠 302 串起来） */
+  followRedirects?: boolean;
+}
+
+/**
+ * 发一次请求：自动带 jar 里的 Cookie、自动攒 Set-Cookie、手动跟随重定向（有跳数上限）。
+ * 重定向时清空自定义 Cookie 头之外的 Host 相关头由调用方自理（这里保留 UA/Accept 等通用头）。
+ */
+export async function requestWithJar(
+  url: string,
+  jar: CookieJar,
+  opts: SessionRequestOptions = {},
+): Promise<RawResponse> {
+  await acquireRequestToken();
+  const { followRedirects = true, headers = {}, ...rest } = opts;
+
+  const merged: Record<string, string> = { ...headers };
+  if (!jar.isEmpty && !merged.Cookie) merged.Cookie = jar.header();
+
+  const resp = await transport(url, { ...rest, headers: merged });
+  jar.absorb(resp.headers["set-cookie"]);
+
+  if (!followRedirects) return resp;
+
+  let current = resp;
+  let hops = 0;
+  let currentUrl = url;
+  // Referer 是「发出这次跳转的那个地址」，不是跳转目的地自己
+  let referer = url;
+  while (current.status >= 300 && current.status < 400 && hops < MAX_REDIRECTS) {
+    const loc = current.headers.location;
+    const target = Array.isArray(loc) ? loc[0] : loc;
+    if (!target) break;
+    referer = currentUrl;
+    currentUrl = new URL(target, currentUrl).toString();
+    hops++;
+    await acquireRequestToken();
+    // 跨主机跳转不能把上一跳的 Cookie 头硬带过去：Cookie 由 jar 重算，
+    // Referer 用发出跳转的地址，其余头保留
+    current = await transport(currentUrl, {
+      method: "GET",
+      headers: { Referer: referer, Cookie: jar.header() },
+    });
+    jar.absorb(current.headers["set-cookie"]);
+  }
+  return current;
+}
+
+/** 表单 POST 的公共头（正方/URP 的 XHR 接口都要求这一组；Cookie 由 jar 统一提供） */
+export function xhrHeaders(referer: string): Record<string, string> {
+  return {
+    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+    Accept: "application/json, text/javascript, */*; q=0.01",
+    "X-Requested-With": "XMLHttpRequest",
+    Referer: referer,
+  };
+}

--- a/src/schools/hebau/index.ts
+++ b/src/schools/hebau/index.ts
@@ -1,0 +1,49 @@
+/**
+ * 河北农业大学适配器
+ *
+ * 认证：CAS 统一认证（cas.hebau.edu.cn，密码 AES-CBC 前端加密，可能触发动态码二次认证）
+ * 数据：正方 URP 学生端（urp.hebau.edu.cn:1009，XHR .do 接口，学期用 XNXQDM 字符串）
+ * 能力：课表 / 成绩 / 考试 / 日历导出。选课、学籍、实验成绩、教务通知没有对应端点，
+ *      一律走 capability 门禁如实报「暂不支持」，不借用南工大的接口猜数据。
+ */
+
+import { HEBAU_PERIOD_TIMES } from "../period-times";
+import { HEBAU_TERM_SEED } from "../term-seeds";
+import type { SchoolAdapter } from "../types";
+import { loginHebau } from "./cas";
+import { fetchHebauExams } from "./exams";
+import { fetchHebauGrades } from "./grades";
+import { fetchHebauSchedule } from "./schedule";
+
+export { HEBAU_PERIOD_TIMES };
+
+const PROMPT_FACTS = `## 本校事实（河北农业大学）
+
+- 认证走学校统一认证（CAS），教务数据来自正方 URP 学生端；统一认证在账密之后可能再要一个动态验证码（短信/微信/企业微信/邮箱/钉钉），工具会明确说「需要二次认证」并给出投递目标——这时向用户索要验证码，拿到后调 submit_auth_code，不要重复触发登录。
+- 已接入能力：课表、成绩与 GPA、考试安排、日历导出（.ics）。
+- 未接入能力（学校教务系统没有提供对应接口，工具会直接返回「暂不支持」）：自主选课/抢课、学籍个人信息、已选课程教学班、可重修课程、实验成绩、教务处通知列表与通知正文读取。用户问这些时如实说明本校尚未接入，建议去教务系统官网查看，不要拿其他学校的口径作答。
+- 成绩绩点是 5.0 满绩制（百分制折算 = 分数/10 - 5），与南工大 4.0 制不可混用；GPA 只算必修课，合格/免修/缓考类不参与。
+- 节次时间与南工大不同（第 1 节 08:00-08:45），说上课时间以工具返回的 time 字段为准，不要按印象推。
+- 校历参照：2026-2027 学年秋冬学期第 1 周自 2026-09-01（周一）起，春夏学期第 1 周自 2027-03-01（周一）起；周次计算以 get_schedule 返回的 week1Monday/weekSource 为准，weekSource=estimated 时要说明是估算值。
+- 寒暑假与法定节假日安排学校没有开放接口也没有落盘记录时，回答「以学校通知/校历为准」，不要凭印象给具体日期。`;
+
+export const hebauAdapter: SchoolAdapter = {
+  id: "hebau",
+  name: "河北农业大学",
+  city: "保定",
+  jwglBase: "http://urp.hebau.edu.cn:1009",
+  newsDomains: ["hebau.edu.cn"],
+  periodTimes: HEBAU_PERIOD_TIMES,
+  // 河北农大春夏学期覆盖 2～7 月（含 7 月初的考试周），比南工大宽一个月
+  secondSemesterMonths: [2, 7],
+  capabilities: ["schedule", "grades", "exams", "calendar"],
+  supportsSecondFactor: true,
+  promptFacts: PROMPT_FACTS,
+  termSeed: HEBAU_TERM_SEED,
+  gpaBasis: "5.0 满绩制，仅必修课计入",
+
+  login: (input) => loginHebau(input),
+  fetchScheduleFor: (session, year, semester) => fetchHebauSchedule(session.cookie, year, semester),
+  fetchExamsFor: (session, year, semester) => fetchHebauExams(session.cookie, year, semester),
+  fetchGrades: (session) => fetchHebauGrades(session.cookie, session.username),
+};

--- a/src/schools/hebau/schedule.ts
+++ b/src/schools/hebau/schedule.ts
@@ -1,0 +1,111 @@
+/**
+ * 河北农大课表抓取与行归一
+ *
+ * URP 的 wdkb 接口按「上课周次」过滤返回（请求参数 SKZC）。这个参数的语义
+ * 是本次接入里唯一没被离线测试覆盖的假设：ScholarFlow 侧写死 16，
+ * 而 16 周之外的课程有可能被过滤掉（南工大校历是 20 个教学周）。
+ * 这里的策略是不赌语义：先不带 SKZC 按全学期取，拿到 0 行再补一轮 SKZC=20。
+ * 真实账号端到端时仍要对比「不传 / 16 / 20」三种取值的课程条数，确认后钉死。
+ */
+
+import type { FetchResult } from "../../jwgl/http";
+import type { CourseData } from "../../jwgl/types";
+import { extractUrpRows, pickString, urpPostSchedule, xnxqdm } from "./urp";
+
+/** 周次规格清洗：去掉「周」字与空白，保留 1-20 / 2-6,8-12 / (单)(双) 这些下游认识的形式 */
+export function normalizeWeekSpec(spec: string): string {
+  return String(spec || "")
+    .replace(/[,，]?\s*全\s*周/g, "")
+    .replace(/周/g, "")
+    .replace(/\s+/g, "")
+    .trim();
+}
+
+/**
+ * 节次展开。SKJC=开始节，JSJC=结束节（多数 URP 接口只给这两个，不给 KSJC），
+ * 再退化到 SKCD（连堂节数）。
+ * 只给 SKJC 而没有长度时按 1 节算——原先 ScholarFlow 兜底成 2 节，
+ * 会把单节课画成两节连堂，宁少不多。
+ */
+export function parsePeriodRange(row: Record<string, unknown>): number[] {
+  const start = intOf(pickString(row, ["SKJC", "skjc", "KSJC", "ksjc"]));
+  if (start <= 0) return [];
+  const jsjc = intOf(pickString(row, ["JSJC", "jsjc"]));
+  const len = intOf(pickString(row, ["SKCD", "skcd"]));
+  let end = start;
+  if (jsjc > 0 && jsjc >= start) end = jsjc;
+  else if (len > 1) end = start + len - 1;
+  const out: number[] = [];
+  for (let p = start; p <= end; p++) out.push(p);
+  return out;
+}
+
+function intOf(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** 单行 -> CourseData。课程名为空的行（场地备注、教师备注）一律丢弃 */
+export function toCourseRow(row: Record<string, unknown>): CourseData | null {
+  const title = pickString(row, ["KCMC", "kcmc", "XSKCM", "xskcm", "KCM", "kcm"]);
+  if (!title) return null;
+  const weekday = intOf(pickString(row, ["XQJ", "xqj", "SKXQ", "skxq", "XQSJC", "xqsjc"]));
+  return {
+    title,
+    weekday,
+    periods: parsePeriodRange(row),
+    weeks: normalizeWeekSpec(pickString(row, ["SKZC", "skzc", "ZCMC", "zcmc", "ZC", "zc"])),
+    location: pickString(row, [
+      "JASMC",
+      "jasmc",
+      "CDMC",
+      "cdmc",
+      "JSMC",
+      "jsmc",
+      "JXLDM_DISPLAY",
+      "jxldm_display",
+      "XQMC",
+      "xqmc",
+    ]),
+    teacher: pickString(row, ["SKJS", "skjs", "JSXM", "jsxm", "JS", "js"]),
+    ...row,
+  };
+}
+
+/** 抓单个学期课表 */
+export async function fetchHebauSchedule(
+  cookie: string,
+  year: number,
+  semester: number,
+): Promise<FetchResult<CourseData[]>> {
+  const xnxqdmValue = xnxqdm(year, semester);
+  const action = `获取${xnxqdmValue}课表`;
+  /** 第一轮不带 SKZC（按全学期取）；仍为空时补一轮 SKZC=20 兜底 */
+  const attempts: Array<number | undefined> = [undefined, 20];
+
+  let lastError = "";
+  for (const skzc of attempts) {
+    const params = new URLSearchParams({ XNXQDM: xnxqdmValue });
+    if (skzc !== undefined) params.set("SKZC", String(skzc));
+    const resp = await urpPostSchedule(cookie, params.toString(), action);
+    if (!resp.ok) {
+      lastError = resp.error;
+      continue;
+    }
+    const rows = extractUrpRows(resp.data, "cxxszhxqkb");
+    if (!rows) {
+      lastError = `${action}失败：教务系统响应结构异常（找不到课表数据行）`;
+      continue;
+    }
+    const courses = rows
+      .map(toCourseRow)
+      .filter((c): c is CourseData => c !== null)
+      .filter((c) => c.weekday >= 1 && c.weekday <= 7);
+    if (courses.length || attempts.length === 1) return { ok: true, data: courses };
+    lastError = "";
+  }
+
+  // 两轮都拿到 0 行且没有报错：确实是空课表（假期/未排课），不是失败
+  if (!lastError) return { ok: true, data: [] };
+  return { ok: false, error: lastError };
+}

--- a/src/schools/hebau/urp.ts
+++ b/src/schools/hebau/urp.ts
@@ -1,0 +1,172 @@
+/**
+ * 河北农大 URP 教务接口层（http://urp.hebau.edu.cn:1009/jwapp/sys/...）
+ *
+ * 与 NJTECH 的 jwgl 同为正方系，但接口形态完全不同：
+ * - NJTECH：`POST /kbcx/xskbcx_cxXsKb.html`，学期用 `xnm=2026&xqm=3` 两个数字字段
+ * - 河北农大：`POST .../cxxszhxqkb.do`，学期用字符串 `XNXQDM=2026-2027-1`
+ * 所以学期编码换算、响应结构摘取都关在本目录里，不外泄。
+ *
+ * 错误语义沿用 src/jwgl/http.ts 的 FetchResult：拿不到数据必须 ok=false，
+ * 绝不能降级成「空列表」——那会被模型转述成「你这学期没课」。
+ */
+
+import type { FetchResult } from "../../jwgl/http";
+import { CookieJar, type RawResponse, requestWithJar, URP_BASE, xhrHeaders } from "./http";
+
+/** 课表 / 考试 / 成绩三个 XHR 端点 */
+export const URP_ENDPOINTS = {
+  schedule: "/jwapp/sys/wdkb/modules/xskcb/cxxszhxqkb.do",
+  exams: "/jwapp/sys/wdkwapp/api/wdks/queryMyExamArrangeMent.do",
+  grades: "/jwapp/sys/cjcx/modules/cjcx/xscjcx.do",
+} as const;
+
+/** 各端点的合法 Referer（URP 校验来源，缺了会被打回首页） */
+const REFERERS = {
+  schedule: `${URP_BASE}/jwapp/sys/homeapp/home/index.html`,
+  exams: `${URP_BASE}/jwapp/sys/wdkwapp/modules/wdks/cxwdksap.do`,
+  grades: `${URP_BASE}/jwapp/sys/cjcx/*default/index.do`,
+} as const;
+
+/**
+ * 内部学期约定沿用工具层的 year + semester（3=秋冬、12=春夏，与 NJTECH 的 xqm 一致），
+ * 到这里换算成 URP 的 XNXQDM 字符串。
+ */
+export function xnxqdm(year: number, semester: number): string {
+  return `${year}-${year + 1}-${semester === 12 ? 2 : 1}`;
+}
+
+/** 会话失效时 URP 不返回 401，而是 200 + 一坨登录页 HTML —— 必须显式识别 */
+function classifyFailure(resp: RawResponse, action: string): string | null {
+  if (resp.status === 0) return `${action}失败：无响应（连接中断）`;
+  if (resp.status >= 500) return `${action}失败：服务端错误 HTTP ${resp.status}`;
+  if (resp.status >= 300 && resp.status < 400) {
+    return `${action}失败：被重定向到登录页（教务会话已失效，请重试一次）`;
+  }
+  if (resp.status !== 200) return `${action}失败，教务系统返回状态 ${resp.status}`;
+  const body = (resp.body || "").trim();
+  if (!body) return `${action}失败：教务系统返回空响应`;
+  if (/<(?:!DOCTYPE|html|body)\b/i.test(body)) {
+    const reauth = /authserver|cas\.hebau|统一认证|重新登录/i.test(body);
+    return `${action}失败：教务系统返回了页面而非数据${reauth ? "（会话已失效，请重试一次）" : "（接口可能已改版）"}`;
+  }
+  return null;
+}
+
+/** POST 一个 URP XHR 接口并把响应解析成 JSON（失败一律 ok=false，带上可读成因） */
+export async function urpPostJson(
+  path: string,
+  cookie: string,
+  body: string,
+  action: string,
+  referer: string,
+): Promise<FetchResult<unknown>> {
+  const jar = CookieJar.fromHeader(cookie);
+  let resp: RawResponse;
+  try {
+    resp = await requestWithJar(`${URP_BASE}${path}`, jar, {
+      method: "POST",
+      headers: xhrHeaders(referer),
+      body,
+    });
+  } catch (e) {
+    return { ok: false, error: `${action}失败：${(e as Error).message}` };
+  }
+  const failure = classifyFailure(resp, action);
+  if (failure) return { ok: false, error: failure };
+  try {
+    return { ok: true, data: JSON.parse(resp.body) as unknown };
+  } catch {
+    return { ok: false, error: `${action}失败：响应不是有效 JSON（接口可能已改版）` };
+  }
+}
+
+export function urpPostSchedule(cookie: string, body: string, action: string) {
+  return urpPostJson(URP_ENDPOINTS.schedule, cookie, body, action, REFERERS.schedule);
+}
+export function urpPostExams(cookie: string, body: string, action: string) {
+  return urpPostJson(URP_ENDPOINTS.exams, cookie, body, action, REFERERS.exams);
+}
+export function urpPostGrades(cookie: string, body: string, action: string) {
+  return urpPostJson(URP_ENDPOINTS.grades, cookie, body, action, REFERERS.grades);
+}
+
+/** 按首个等号切 KV：值里带等号（Base64 票据常见）时不能被后面的等号切坏 */
+function pickRows(container: unknown): Record<string, unknown>[] | null {
+  if (!container || typeof container !== "object") return null;
+  const rows = (container as Record<string, unknown>).rows;
+  return Array.isArray(rows) ? rows.filter(isRow) : null;
+}
+
+function isRow(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * 摘数据行。URP 各接口的包装层级不一样，实测出现过这三种形态：
+ *   { datas: { <接口名>: { rows: [...] } } }   ← 课表/成绩
+ *   { datas: { queryMyExamArrangeMent: { arranged: [...], notArranged: [...] } } }  ← 考试
+ *   { rows: [...] } / [...]                    ← 兜底
+ * 拿不到行返回 null（= 结构异常，调用方必须报错），空数组才是「确实没数据」。
+ * 这个区分很重要：把结构改版当成「没课」，用户会以为这学期真的没排课。
+ */
+export function extractUrpRows(
+  payload: unknown,
+  datasKey?: string,
+): Record<string, unknown>[] | null {
+  if (Array.isArray(payload)) return payload.filter(isRow);
+  if (!payload || typeof payload !== "object") return null;
+
+  const root = payload as Record<string, unknown>;
+  const datas = asObject(root.datas);
+  if (datas) {
+    // 优先按接口名精确取；取不到就扫所有子对象，改版换了 key 也不至于全线失效
+    const named = asObject(datasKey ? datas[datasKey] : undefined);
+    const direct = named ? pickRows(named) : null;
+    if (direct) return direct;
+    for (const value of Object.values(datas)) {
+      const rows = pickRows(value);
+      if (rows) return rows;
+      const buckets = multiBucketRows(value);
+      if (buckets) return buckets;
+    }
+  }
+
+  const data = asObject(root.data) ? asObject(root.data) : undefined;
+  if (Array.isArray(root.data)) return (root.data as unknown[]).filter(isRow);
+  if (data) {
+    const rows = pickRows(data);
+    if (rows) return rows;
+    const buckets = multiBucketRows(data);
+    if (buckets) return buckets;
+  }
+  if (Array.isArray(root.rows)) return (root.rows as unknown[]).filter(isRow);
+  return null;
+}
+
+/** 考试接口把行拆成 arranged / notArranged 两个桶，合并成一份 */
+function multiBucketRows(container: unknown): Record<string, unknown>[] | null {
+  const obj = asObject(container);
+  if (!obj) return null;
+  const out: Record<string, unknown>[] = [];
+  for (const key of ["arranged", "notArranged", "rows", "data"]) {
+    const value = obj[key];
+    if (Array.isArray(value)) out.push(...value.filter(isRow));
+  }
+  return out.length ? out : null;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** URP 字段大小写与别名混杂（KCMC/kcmc/XSKCM…），按候选顺序取第一个非空串 */
+export function pickString(row: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = row[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  }
+  return "";
+}

--- a/src/schools/ids.ts
+++ b/src/schools/ids.ts
@@ -1,0 +1,32 @@
+/**
+ * 学校标识登记表（叶子模块：只依赖调用方传进来的原始字符串，不 import 适配器）
+ *
+ * 为什么单独一个文件：config.ts 要在启动时就校验 RAPTOR_SCHOOL，而校验不能去
+ * import 适配器（适配器 import 抓取模块，抓取模块又 import config —— 循环依赖）。
+ * 所以「有哪些学校」这份名单放叶子模块，注册表另处断言名单与适配器一一对应。
+ */
+
+export const DEFAULT_SCHOOL_ID = "njtech";
+
+/** 已知学校 id。新增学校必须同时在这里和 registry 里登记 */
+export const KNOWN_SCHOOL_IDS = ["njtech", "hebau"] as const;
+
+export type KnownSchoolId = (typeof KNOWN_SCHOOL_IDS)[number];
+
+export function isKnownSchoolId(id: string): id is KnownSchoolId {
+  return (KNOWN_SCHOOL_IDS as readonly string[]).includes(id);
+}
+
+/** 校验 RAPTOR_SCHOOL 取值。未知值必须硬失败，见 normalizeSchoolId 的注释 */
+export function normalizeSchoolId(raw: string | undefined): string {
+  const id = (raw ?? "").trim().toLowerCase();
+  if (!id) return DEFAULT_SCHOOL_ID;
+  if (!isKnownSchoolId(id)) {
+    throw new Error(
+      `RAPTOR_SCHOOL="${raw}" 不是已知学校。可选值：${KNOWN_SCHOOL_IDS.join(" | ")}。` +
+        `（不回退到默认学校是故意的：拿着一所学校的密码去登录另一所学校的教务系统，` +
+        `等于把凭证发给无关的服务器。）`,
+    );
+  }
+  return id;
+}

--- a/src/schools/mfa.ts
+++ b/src/schools/mfa.ts
@@ -1,0 +1,177 @@
+/**
+ * 二次认证（动态码）待验证会话存储
+ *
+ * 场景：河北农大走 CAS 统一认证，账密通过后常被要求再填一个手机/邮箱验证码。
+ * 对话式 agent 拿不到用户手机，只能：
+ *   第 1 轮 登录 -> 抛「需要验证码，已发往 138****1234」 -> 存下待验证会话
+ *   第 2 轮 用户把验证码发进对话 -> 模型调 submit_auth_code -> 用同一份 Cookie 续完登录
+ *
+ * 因此待验证状态必须跨请求活着，而且要落盘而不是只在内存里：
+ * 网页/TUI 与 QQ 桥是两个进程，用户也很可能在上一个窗口问完、下一个窗口才回验证码。
+ *
+ * 三条护栏：
+ * 1. 校验 challengeId 时必须同时匹配学校与学号，防止拿别人的 challenge 冒领会话。
+ * 2. 10 分钟过期（CAS 侧验证码本身也短命），过期即销毁。
+ * 3. 存储里是 Cookie（等同临时登录态），落在 data/ 下——data 整体不打包、不参与更新覆盖。
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { quarantineCorruptFileSync, writeFileAtomicSync } from "../atomic-write";
+import { PROJECT_ROOT } from "../paths";
+
+const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+
+export interface PendingSecondFactor {
+  challengeId: string;
+  schoolId: string;
+  username: string;
+  /** CAS 侧这次要求哪种二次认证（3=短信 4=微信 5=企业微信 11=邮箱 12=钉钉 13=WeLink） */
+  reAuthType: string;
+  isMultifactor: string;
+  /** 脱敏后的投递目标，如手机号/邮箱，只用于给用户说明验证码发去哪了 */
+  maskedTarget: string;
+  /** 已持有的认证 Cookie，提交验证码时要在同一份 Cookie 上继续 */
+  cookies: [string, string][];
+  serviceUrl: string;
+  createdAt: number;
+}
+
+function storePath(): string {
+  const dir = process.env.RAPTOR_DATA_DIR ?? path.join(PROJECT_ROOT, "data");
+  return path.join(dir, "school-mfa.json");
+}
+
+function readStore(): Record<string, PendingSecondFactor> {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storePath(), "utf8")) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, PendingSecondFactor>;
+    }
+    return {};
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      // 文件在却解析不出来：留副本再当空的，别让半截 JSON 把待验证会话无声吞掉
+      quarantineCorruptFileSync(storePath());
+    }
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, PendingSecondFactor>): void {
+  try {
+    writeFileAtomicSync(storePath(), JSON.stringify(store, null, 2));
+  } catch {
+    // 只读环境下退化为「验证码流程不可用」，不影响其他工具
+  }
+}
+
+function isPending(value: unknown): value is PendingSecondFactor {
+  if (!value || typeof value !== "object") return false;
+  const p = value as Partial<PendingSecondFactor>;
+  return (
+    typeof p.challengeId === "string" &&
+    typeof p.schoolId === "string" &&
+    typeof p.username === "string" &&
+    typeof p.createdAt === "number" &&
+    Array.isArray(p.cookies)
+  );
+}
+
+/** 丢掉过期/结构损坏的条目，返回清理后的存储（同时回写磁盘） */
+function prune(now = Date.now()): Record<string, PendingSecondFactor> {
+  const raw = readStore();
+  const kept: Record<string, PendingSecondFactor> = {};
+  let dirty = false;
+  for (const [id, value] of Object.entries(raw)) {
+    if (!isPending(value) || now - value.createdAt > CHALLENGE_TTL_MS) {
+      dirty = true;
+      continue;
+    }
+    kept[id] = value;
+  }
+  if (dirty) writeStore(kept);
+  return kept;
+}
+
+/**
+ * 登记一次待验证会话。同一账号只保留最新一条：
+ * 用户重复问「今天课表」会反复触发登录，留着旧 challenge 只会让验证码对不上。
+ */
+export function beginSecondFactor(
+  input: Omit<PendingSecondFactor, "challengeId" | "createdAt">,
+): string {
+  const challengeId = `${input.schoolId}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const store = prune();
+  for (const [id, pending] of Object.entries(store)) {
+    if (pending.schoolId === input.schoolId && pending.username === input.username)
+      delete store[id];
+  }
+  store[challengeId] = { ...input, challengeId, createdAt: Date.now() };
+  writeStore(store);
+  return challengeId;
+}
+
+/** 取出并校验归属（不删除：验证码可能一次填错，删除得由调用方显式做） */
+export function readSecondFactor(
+  challengeId: string,
+  schoolId: string,
+  username: string,
+): PendingSecondFactor | string {
+  const pending = prune()[challengeId];
+  if (!pending) return "验证码会话不存在或已过期（超过 10 分钟），请重新查询触发新的验证码";
+  if (pending.schoolId !== schoolId) return "验证码会话与当前配置的学校不匹配，请重新查询";
+  if (pending.username !== username.trim()) return "验证码会话与当前学号不匹配，请重新查询";
+  return pending;
+}
+
+export function clearSecondFactor(challengeId: string): void {
+  const store = prune();
+  if (!(challengeId in store)) return;
+  delete store[challengeId];
+  writeStore(store);
+}
+
+/** 测试与 /reset 用：清空全部待验证会话 */
+export function clearAllSecondFactors(): void {
+  try {
+    fs.rmSync(storePath(), { force: true });
+  } catch {
+    /* 不存在就算了 */
+  }
+}
+
+/**
+ * 找当前账号唯一有效的待验证会话。
+ * 用户通常只会把验证码原文发过来，不记得 challenge id —— 而 beginSecondFactor
+ * 保证同一「学校+学号」只保留最新一条，所以这里可以安全地按账号定位。
+ */
+export function findSecondFactor(schoolId: string, username: string): PendingSecondFactor | null {
+  const store = prune();
+  const wanted = username.trim();
+  for (const pending of Object.values(store)) {
+    if (pending.schoolId === schoolId && pending.username === wanted) return pending;
+  }
+  return null;
+}
+
+/**
+ * 需要验证码时抛出的信号错误。
+ * message 是给模型看的：必须含「把验证码发给我」这个可执行动作，
+ * 否则模型会把它当普通失败转述成「登录失败，请稍后再试」。
+ */
+export class SecondFactorRequiredError extends Error {
+  readonly challengeId: string;
+  readonly maskedTarget: string;
+
+  constructor(challengeId: string, maskedTarget: string) {
+    super(
+      `需要二次认证：验证码已发送到${maskedTarget || "绑定的手机/邮箱"}，` +
+        `10 分钟内有效。请向用户索要验证码原文，拿到后调用 submit_auth_code(code, challenge_id="${challengeId}") 完成登录，` +
+        `然后重新执行刚才的查询。在用户提供验证码之前不要重复触发登录。`,
+    );
+    this.name = "SecondFactorRequiredError";
+    this.challengeId = challengeId;
+    this.maskedTarget = maskedTarget;
+  }
+}

--- a/src/schools/njtech.ts
+++ b/src/schools/njtech.ts
@@ -1,0 +1,65 @@
+/**
+ * 南京工业大学适配器
+ *
+ * 这一层是「包装」而不是「重写」：src/jwgl/* 那套抓取模块本来就是南工大专用的
+ * （jwgl.njtech.edu.cn + RSA 登录 + xnm/xqm 学期编码），搬进来只会平白制造两套真相。
+ * 所以本文件只做三件事：声明本校能力清单与节次表、把三个抓取原语按 SchoolAdapter
+ * 契约接上、把原来写死在系统提示词里的南工大专属事实挪到学校这边。
+ */
+
+import { fetchExamsFor, fetchScheduleFor, NJTECH_PERIOD_TIMES } from "../jwgl/academics";
+import { BASE, loginJwgl } from "../jwgl/auth";
+import { fetchAllGrades } from "../jwgl/grades";
+import { NJTECH_TERM_SEED } from "./term-seeds";
+import type { SchoolAdapter } from "./types";
+
+const PROMPT_FACTS = `## 背景知识（重要）
+
+- 教务系统是正方新版，选课模块为「自主选课 zzxkyzb」。
+- 教务线路偶发抖动：登录失败会自动重试（最多 5 次），若工具报「登录失败」让用户稍后再试即可。
+- 学校侧停用的模块（任何客户端都查不到）：空闲教室、班级课表、学业情况、实验课表、培养方案、站内通知。用户问这些时如实说明教务系统未开放该模块。
+
+## 校历（2026-2027 学年，2026-08-30 按官方校历核对）
+
+- 秋冬学期：注册 2026-08-29～08-30；第 1 周 2026-08-31（周一）～9-06，共 20 个教学周；本科新生报到 9-05～09-06（军训 9-14～09-30）
+- 元旦 2027-01-01；寒假 2027-01-09～02-26（春节 2027-02-06）
+- 春夏学期：注册 2027-02-27～02-28；第 1 周 2027-03-01（周一）；暑假 2027-07-10～08-27
+- 周次计算的运行时真值是 data/term-dates.json（get_schedule 返回的 week1Monday/weekNote），此处仅为背景参照，两者不一致时以工具返回为准
+- 具体哪天放假、哪天调休补课教务处临近才发通知，处理流程见行为准则第 12 条；校历原图存于 outputs/njtech-calendar-2026-2027.jpg`;
+
+export const njtechAdapter: SchoolAdapter = {
+  id: "njtech",
+  name: "南京工业大学",
+  city: "南京",
+  jwglBase: BASE,
+  newsDomains: ["njtech.edu.cn"],
+  periodTimes: NJTECH_PERIOD_TIMES,
+  // 南工大春夏学期覆盖 2～6 月
+  secondSemesterMonths: [2, 6],
+  capabilities: [
+    "schedule",
+    "grades",
+    "exams",
+    "generalElectives",
+    "news",
+    "notice",
+    "student",
+    "enrolledCourses",
+    "retakeCourses",
+    "labGrades",
+    "courseSelection",
+    "calendar",
+  ],
+  supportsSecondFactor: false,
+  promptFacts: PROMPT_FACTS,
+  termSeed: NJTECH_TERM_SEED,
+  gpaBasis: "4.0 制，仅必修课计入",
+
+  login: async ({ username, password }) => {
+    const session = await loginJwgl(username, password);
+    return { cookie: session.cookie, username: session.username };
+  },
+  fetchScheduleFor: (session, year, semester) => fetchScheduleFor(session.cookie, year, semester),
+  fetchExamsFor: (session, year, semester) => fetchExamsFor(session.cookie, year, semester),
+  fetchGrades: (session) => fetchAllGrades(session.cookie, session.username),
+};

--- a/src/schools/period-times.ts
+++ b/src/schools/period-times.ts
@@ -1,0 +1,69 @@
+/**
+ * 各校节次时间表 —— 唯一真值
+ *
+ * 为什么单独一个叶子模块：节次号 → 上课时间这件事看起来归「课表抓取」管，
+ * 但真正用到它的是三处下游（get_schedule 的 time 字段、buildWeekIndex 的预格式化行、
+ * 日历导出与 TUI 启动面板）。如果让抓取模块去 import 学校注册表拿表，就成环了
+ * （academics → registry → njtech 适配器 → academics）。所以把表放叶子模块：
+ * 下游只 import 这里，适配器也从这里取，谁都不绕。
+ *
+ * 南工大与河北农大的第 1 节差 10 分钟、下午差 30 分钟。共用一张表的话，
+ * 河农大的课会集体早/晚 10-30 分钟出现在日历里——这种错很难被肉眼发现。
+ */
+
+import { config } from "../config";
+
+/** 南京工业大学：每节 45 分钟，课间 10 分钟（第 1 节 08:10） */
+export const NJTECH_PERIOD_TIMES: Record<string, string> = {
+  "1": "08:10-08:55",
+  "2": "09:05-09:50",
+  "3": "10:20-11:05",
+  "4": "11:15-12:00",
+  "5": "14:00-14:45",
+  "6": "14:55-15:40",
+  "7": "16:00-16:45",
+  "8": "16:55-17:40",
+  "9": "19:00-19:45",
+  "10": "19:55-20:40",
+};
+
+/** 河北农业大学：第 1 节 08:00，下午 14:30 起，晚自习 18:40 起 */
+export const HEBAU_PERIOD_TIMES: Record<string, string> = {
+  "1": "08:00-08:45",
+  "2": "08:55-09:40",
+  "3": "10:10-10:55",
+  "4": "11:05-11:50",
+  "5": "14:30-15:15",
+  "6": "15:25-16:10",
+  "7": "16:20-17:05",
+  "8": "17:15-18:00",
+  "9": "18:40-19:25",
+  "10": "19:35-20:20",
+};
+
+const TABLES: Record<string, Record<string, string>> = {
+  njtech: NJTECH_PERIOD_TIMES,
+  hebau: HEBAU_PERIOD_TIMES,
+};
+
+/** 按学校取节次表；未登记的学校退回南工大表（当前只有这两套教务） */
+export function periodTableFor(schoolId: string): Record<string, string> {
+  return TABLES[schoolId] ?? NJTECH_PERIOD_TIMES;
+}
+
+/** 当前生效学校的节次表 */
+export function activePeriodTable(): Record<string, string> {
+  return periodTableFor(config.school);
+}
+
+/** 节次号 -> 起止时间，如 [7,8] -> "16:00-17:40"。表里没有该节次时返回 undefined */
+export function periodTimeRangeWith(
+  table: Record<string, string>,
+  periods: number[],
+): string | undefined {
+  if (!periods.length) return undefined;
+  const first = table[String(periods[0])];
+  const last = table[String(periods[periods.length - 1])];
+  if (!first || !last) return undefined;
+  return `${first.split("-")[0]}-${last.split("-")[1]}`;
+}

--- a/src/schools/probe.ts
+++ b/src/schools/probe.ts
@@ -1,0 +1,144 @@
+/**
+ * 学期探测循环（与学校无关的那一半）
+ *
+ * 为什么单独一个文件：「不知道现在是哪个学期」这件事每所学校都会遇到——
+ * 正方系教务系统都不提供「当前学期」查询接口，按日历日期硬推在学期交界期必然出错
+ * （8 月下旬新学期课表已生成、1 月还在秋学期里）。解法是候选学期逐个试，
+ * 取第一个真有数据的。这个循环本身跟学校无关，学校只提供两件事：
+ * 每个学期怎么抓（适配器）、春夏学期占哪几个月（secondSemesterMonths）。
+ *
+ * 语义约定与 jwgl/academics.ts 完全一致，这点很重要：
+ * - ok=false = 一个学期都没查通（断网/会话失效/接口改版），必须如实上报；
+ * - ok=true 且列表为空 = 确实查到了但没排课（假期属正常）。
+ * 混为一谈会让 agent 把「教务系统连不上」说成「你这学期没课」。
+ */
+
+import { type ExamResult, type ScheduleResult, termLabel } from "../jwgl/academics";
+import type { FetchResult } from "../jwgl/http";
+import type { ExamData } from "../jwgl/types";
+import type { SchoolAdapter, SchoolSession } from "./types";
+
+export interface ProbeOptions {
+  /** 指定学年（如 2026 表示 2026-2027）与学期（3=秋冬，12=春夏）。都不传则自动探测 */
+  year?: number;
+  semester?: number;
+  /** 会话失效时重建会话的回调（工具层传 getCookie(true)）。不传则不重试 */
+  refresh?: () => Promise<SchoolSession>;
+  now?: Date;
+}
+
+/**
+ * 候选学期（新到旧）。
+ *
+ * 与 NJTECH 原 candidateXnxqList 的分支逐条对齐（南工大 months=[2,6] 时结果完全相同），
+ * 差别只在春夏学期的月份区间换成学校自己的：
+ * - m >= 9：秋学期进行中
+ * - hi < m < 9：假期/交界（南工大 7-8 月，河农大 8 月），新学期课表通常已生成，先探秋
+ * - m <= hi：春学期进行中（学年始于上一年）
+ */
+export function candidateTerms(
+  months: readonly [number, number],
+  now: Date = new Date(),
+): Array<{ year: number; semester: number }> {
+  const y = now.getFullYear();
+  const m = now.getMonth() + 1;
+  const [, hi] = months;
+  if (m >= 9) {
+    return [
+      { year: y, semester: 3 },
+      { year: y - 1, semester: 12 },
+    ];
+  }
+  if (m > hi) {
+    return [
+      { year: y, semester: 3 },
+      { year: y - 1, semester: 12 },
+      { year: y - 1, semester: 3 },
+    ];
+  }
+  return [
+    { year: y - 1, semester: 12 },
+    { year: y - 1, semester: 3 },
+  ];
+}
+
+/** 会话失效的可读信号。各校文案不同，只能按关键词认 */
+function looksLikeExpiredSession(error: string): boolean {
+  return /会话|失效|登录页|重新登录/.test(error);
+}
+
+type Fetcher<T extends unknown[]> = (
+  school: SchoolAdapter,
+  session: SchoolSession,
+  year: number,
+  semester: number,
+) => Promise<FetchResult<T>>;
+
+/**
+ * 候选学期通用探测：从新到旧取第一个「有数据」的学期。
+ * 全部候选都失败才 ok=false；只要有一个学期查通且为空，就保持「空但不算失败」语义。
+ */
+async function probe<T extends unknown[]>(
+  school: SchoolAdapter,
+  session: SchoolSession,
+  fetcher: Fetcher<T>,
+  opts: ProbeOptions,
+): Promise<{ term: { year: number; semester: number }; data: T } | { error: string }> {
+  const specified =
+    opts.year && opts.semester ? [{ year: opts.year, semester: opts.semester }] : undefined;
+  const candidates = specified ?? candidateTerms(school.secondSemesterMonths, opts.now);
+  let current = session;
+  let refreshed = false;
+
+  const failures: string[] = [];
+  let emptyButOk: { term: { year: number; semester: number }; data: T } | null = null;
+
+  for (const term of candidates) {
+    let r = await fetcher(school, current, term.year, term.semester);
+    // 会话中途过期：拿不到任何数据，重建一次会话再试同一学期
+    if (!r.ok && !refreshed && opts.refresh && looksLikeExpiredSession(r.error)) {
+      refreshed = true;
+      current = await opts.refresh();
+      r = await fetcher(school, current, term.year, term.semester);
+    }
+    if (!r.ok) {
+      failures.push(`${termLabel(term.year, term.semester)}：${r.error}`);
+      continue;
+    }
+    if (r.data.length > 0) return { term, data: r.data };
+    emptyButOk ??= { term, data: r.data };
+  }
+
+  if (emptyButOk) return emptyButOk;
+  return { error: failures.join("；") || "所有候选学期都查不到数据" };
+}
+
+export async function probeSchedule(
+  school: SchoolAdapter,
+  session: SchoolSession,
+  opts: ProbeOptions = {},
+): Promise<FetchResult<ScheduleResult>> {
+  const r = await probe(school, session, (s, sesh, y, q) => s.fetchScheduleFor(sesh, y, q), opts);
+  if ("error" in r) return { ok: false, error: `课表查询失败：${r.error}` };
+  return {
+    ok: true,
+    data: { ...r.term, label: termLabel(r.term.year, r.term.semester), courses: r.data },
+  };
+}
+
+export async function probeExams(
+  school: SchoolAdapter,
+  session: SchoolSession,
+  opts: ProbeOptions = {},
+): Promise<FetchResult<ExamResult>> {
+  const r = await probe(school, session, (s, sesh, y, q) => s.fetchExamsFor(sesh, y, q), opts);
+  if ("error" in r) return { ok: false, error: `考试查询失败：${r.error}` };
+  return {
+    ok: true,
+    data: {
+      ...r.term,
+      label: termLabel(r.term.year, r.term.semester),
+      exams: r.data as ExamData[],
+    },
+  };
+}

--- a/src/schools/registry.ts
+++ b/src/schools/registry.ts
@@ -1,0 +1,64 @@
+/**
+ * 学校注册表 —— RAPTOR_SCHOOL 到适配器的唯一映射点
+ *
+ * 只有一个地方允许「知道有哪些学校」：本文件的 ADAPTERS。工具层一律
+ * `activeSchool()` + capability 判断，写 `if (school === "hebau")` 就是设计失败——
+ * 那样第三所学校进来时要改一遍所有工具。
+ */
+
+import { config } from "../config";
+import { hebauAdapter } from "./hebau";
+import { KNOWN_SCHOOL_IDS } from "./ids";
+import { njtechAdapter } from "./njtech";
+import type { SchoolAdapter } from "./types";
+import { type SchoolCapability, supportsCapability } from "./types";
+
+const ADAPTERS: ReadonlyMap<string, SchoolAdapter> = new Map<string, SchoolAdapter>(
+  [njtechAdapter, hebauAdapter].map((adapter) => [adapter.id, adapter]),
+);
+
+/** 名单与适配器必须同步。漏登记时 ids.ts 允许配置、这里却查不到 → 运行时才炸，
+ *  所以启动即断言（loadSchoolRegistry 由 activeSchool 第一次调用时执行）。 */
+function assertRegistered(): void {
+  for (const id of KNOWN_SCHOOL_IDS) {
+    if (!ADAPTERS.has(id)) {
+      throw new Error(
+        `学校 "${id}" 在 src/schools/ids.ts 登记了但没有适配器，请补注册或从名单删除`,
+      );
+    }
+  }
+}
+
+let memo: { id: string; adapter: SchoolAdapter } | null = null;
+
+/** 当前生效的学校。按 config.school 解析一次后缓存 */
+export function activeSchool(): SchoolAdapter {
+  if (memo && memo.id === config.school) return memo.adapter;
+  assertRegistered();
+  const adapter = ADAPTERS.get(config.school);
+  if (!adapter) {
+    // config 已经拦过一遍，走到这里说明有代码绕过了 normalizeSchoolId
+    throw new Error(`未知学校 "${config.school}"，可选：${KNOWN_SCHOOL_IDS.join(" | ")}`);
+  }
+  memo = { id: config.school, adapter };
+  return adapter;
+}
+
+export function getSchool(id: string): SchoolAdapter | undefined {
+  return ADAPTERS.get(id);
+}
+
+export function allSchools(): SchoolAdapter[] {
+  assertRegistered();
+  return [...ADAPTERS.values()];
+}
+
+/** 学校是否有某能力（工具层门禁的唯一入口） */
+export function schoolSupports(cap: SchoolCapability): boolean {
+  return supportsCapability(activeSchool(), cap);
+}
+
+/** 测试用：清掉缓存，让改了 config.school 的用例重新解析 */
+export function resetSchoolCache(): void {
+  memo = null;
+}

--- a/src/schools/term-seeds.ts
+++ b/src/schools/term-seeds.ts
@@ -1,0 +1,57 @@
+/**
+ * 开学日期（第 1 周周一）播种表 —— 一校一份
+ *
+ * 为什么必须有学校维度：这些日期原先只有南工大一套真值，落在 data/term-dates.json。
+ * 如果接了河北农大还共用一个文件，南工大的「2026 秋 = 08-31」会被当成河北农大的
+ * 开学日（河农大是 09-01），整个学期的周次系统性错一周——而且错得很像对的，
+ * 用户不会发现。所以：文件按学校分开，种子表按学校分开。
+ *
+ * 本模块必须是叶子：src/jwgl/term-dates.ts 要 import 它，而它只能反向 import 类型
+ * （type-only，运行时被擦除），否则循环依赖。
+ */
+
+import type { TermStartDate } from "../jwgl/term-dates";
+
+/** 南工大：2025 两学期人工按校历校准；2026 秋依据南工教〔2026〕91号 */
+export const NJTECH_TERM_SEED: Record<string, TermStartDate> = {
+  "2025-1": { week1Monday: "2025-09-01", source: "known", evidence: "人工按校历校准" },
+  "2025-2": { week1Monday: "2026-03-02", source: "known", evidence: "人工按校历校准" },
+  "2026-1": {
+    week1Monday: "2026-08-31",
+    source: "known",
+    evidence: "南工教〔2026〕91号：报到 8-29～8-30、注册 8-31～9-30（修正此前 9-07 的估算）",
+  },
+};
+
+/**
+ * 河北农大：沿用 ScholarFlow 侧人工整理的校历表（lib/schools/hebau/index.ts）。
+ * source 标 "known" 而非 "recorded"：有确定依据，但没有可追溯的通知解析链路。
+ */
+export const HEBAU_TERM_SEED: Record<string, TermStartDate> = {
+  "2025-1": {
+    week1Monday: "2025-09-01",
+    source: "known",
+    evidence: "河北农大校历（ScholarFlow 整理）",
+  },
+  "2025-2": {
+    week1Monday: "2026-03-02",
+    source: "known",
+    evidence: "河北农大校历（ScholarFlow 整理）",
+  },
+  "2026-1": {
+    week1Monday: "2026-09-01",
+    source: "known",
+    evidence: "河北农大校历（ScholarFlow 整理）",
+  },
+  "2026-2": {
+    week1Monday: "2027-03-01",
+    source: "known",
+    evidence: "河北农大校历（ScholarFlow 整理）",
+  },
+};
+
+/** 学校 id -> 播种表。未登记的学校不播种，一律按月份估算并如实标 estimated */
+export const TERM_SEEDS: Record<string, Record<string, TermStartDate>> = {
+  njtech: NJTECH_TERM_SEED,
+  hebau: HEBAU_TERM_SEED,
+};

--- a/src/schools/types.ts
+++ b/src/schools/types.ts
@@ -1,0 +1,138 @@
+/**
+ * 学校适配器契约 —— agent 侧的「一校一适配」边界
+ *
+ * 为什么要有这一层：
+ * 教务抓取原本直接写死 NJTECH（src/jwgl/auth.ts 导出一个 BASE 常量，被 5 个模块
+ * import）。接第二所学校时，如果不设边界，最省事的做法是到处 `if (school === "hebau")`，
+ * 结果是任何一所学校的接口改版都要改十几个文件，而且很容易出现「用河北农大的密码
+ * 去请求南工大教务」这种凭证外泄事故。所以：
+ *
+ * - 一所学校 = 一个适配器。端点、登录方式、字段名、绩点口径都关在适配器里。
+ * - 工具层只认 SchoolAdapter 接口 + capability 清单，不再认学校名。
+ * - 学校没有对应端点的能力必须走 capability 门禁明确报「暂不支持」，
+ *   绝不允许退回另一所学校的接口去猜——宁缺毋滥，错的数据比没有数据更坏。
+ *
+ * 术语沿用 jwgl/types.ts 的数据结构（CourseData/ExamData/GradeResult），
+ * 这样课表分组、学业概览、日历导出这些下游纯计算逻辑可以零改动复用。
+ */
+
+import type { FetchResult } from "../jwgl/http";
+import type { TermStartDate } from "../jwgl/term-dates";
+import type { CourseData, ExamData, GradeResult } from "../jwgl/types";
+
+/**
+ * 能力键。粒度按「工具能不能干活」划分，不按学校划分——
+ * 加学校时只需要填这张表，改工具时只需要问一句「这能力有没有」。
+ */
+export type SchoolCapability =
+  /** get_schedule 课表查询 */
+  | "schedule"
+  /** get_grades 成绩与 GPA */
+  | "grades"
+  /** get_exams 考试安排 */
+  | "exams"
+  /** 通识选修六类分类统计（依赖成绩里的课程归属字段） */
+  | "generalElectives"
+  /** get_news 教务处通知列表 */
+  | "news"
+  /** read_notice / fetch_attachment 通知正文与附件 */
+  | "notice"
+  /** get_student_info 学籍信息 */
+  | "student"
+  /** get_enrolled_courses 已选课程教学班 */
+  | "enrolledCourses"
+  /** get_retake_courses 可重修课程 */
+  | "retakeCourses"
+  /** get_lab_grades 实验成绩 */
+  | "labGrades"
+  /** 选课/盯课/抢课一族 */
+  | "courseSelection"
+  /** export_calendar / publish_calendar（只要有课表和考试就能导） */
+  | "calendar";
+
+export interface SchoolSession {
+  /** 后续抓取请求带的 Cookie 串 */
+  cookie: string;
+  username: string;
+}
+
+export interface SchoolLoginInput {
+  username: string;
+  password: string;
+  /** 二次认证：上一轮拿到的 challengeId，与 dynamicCode 同时传表示提交验证码 */
+  challengeId?: string;
+  dynamicCode?: string;
+}
+
+export interface SchoolAdapter {
+  /** 稳定标识，同时是 data 目录下按学校分文件的后缀 */
+  id: string;
+  /** 全称，用于文案与系统提示词 */
+  name: string;
+  /** 城市名（get_weather 默认城市）。写死在学校中，不要靠主机名猜 */
+  city: string;
+  /** 教务系统基础 URL（展示与诊断用；凭证只会发往这一处） */
+  jwglBase: string;
+  /** read_notice/fetch_attachment 允许直读的官网域名后缀 */
+  newsDomains: string[];
+  /** 节次号 -> 时间段，如 "1" -> "08:00-08:45" */
+  periodTimes: Record<string, string>;
+  /** 春夏学期覆盖的月份区间（含端点），学期归属推断用 */
+  secondSemesterMonths: readonly [number, number];
+  capabilities: readonly SchoolCapability[];
+  /** 登录是否可能要求二次认证（触发对话内提交验证码流程） */
+  supportsSecondFactor: boolean;
+  /** 学校专属的提示词事实：教务形态、已知校历、学校侧停用模块 */
+  promptFacts: string;
+  /** 开学日期播种值（`${学年}-${1|2}` -> 真值），仅在 data 文件不存在时用一次 */
+  termSeed: Record<string, TermStartDate>;
+  /** GPA 口径一句话说明，供工具层如实转述 */
+  gpaBasis: string;
+
+  login(input: SchoolLoginInput): Promise<SchoolSession>;
+  /** 抓单个学期课表。学期编码由适配器自己换算 */
+  fetchScheduleFor(
+    session: SchoolSession,
+    year: number,
+    semester: number,
+  ): Promise<FetchResult<CourseData[]>>;
+  /** 抓单个学期考试 */
+  fetchExamsFor(
+    session: SchoolSession,
+    year: number,
+    semester: number,
+  ): Promise<FetchResult<ExamData[]>>;
+  /** 抓全部学期成绩并算 GPA */
+  fetchGrades(session: SchoolSession): Promise<GradeResult>;
+}
+
+export function supportsCapability(school: SchoolAdapter, cap: SchoolCapability): boolean {
+  return school.capabilities.includes(cap);
+}
+
+/** 能力键的中文名。门禁话术与 get_school_status 清单共用一份，避免两处各写一遍 */
+export const CAPABILITY_LABELS: Record<SchoolCapability, string> = {
+  schedule: "课表查询",
+  grades: "成绩查询",
+  exams: "考试安排查询",
+  generalElectives: "通识选修分类统计",
+  news: "教务处通知列表",
+  notice: "通知正文读取",
+  student: "学籍个人信息",
+  enrolledCourses: "已选课程查询",
+  retakeCourses: "可重修课程查询",
+  labGrades: "实验成绩",
+  courseSelection: "选课/抢课",
+  calendar: "日历导出",
+};
+
+/**
+ * 门禁话术。返回给模型的文本要能直接转述给用户，所以：
+ * 说清是「学校没开这个接口」而不是「你查错了」，并给出可行的下一步。
+ */
+export function unsupportedCapabilityMessage(school: SchoolAdapter, cap: SchoolCapability): string {
+  return (
+    `${CAPABILITY_LABELS[cap]}暂不支持：${school.name}的教务系统没有提供对应接口，` +
+    `CourseRaptor 不会拿其他学校的接口猜数据。需要这项信息请到${school.name}教务系统官网查看。`
+  );
+}

--- a/src/tools/course-selection.ts
+++ b/src/tools/course-selection.ts
@@ -19,6 +19,8 @@ import {
   type XkSession,
   type XkTarget,
 } from "../jwgl/xk";
+import { activeSchool } from "../schools/registry";
+import { supportsCapability, unsupportedCapabilityMessage } from "../schools/types";
 import { getXkSession, invalidateXkSession, pollDelay } from "./session";
 
 function now(): string {
@@ -386,6 +388,10 @@ export const courseSelectionTools = {
       "查询南京工业大学教务系统「自主选课」模块的当前状态：选课是否开放（iskxk）、选课控制 ID（xkkzId）、以及课程查询接口是否仍返回「加密串错误」（防爬拦截）。回答任何选课相关问题前建议先调用此工具确认状态。",
     inputSchema: z.object({}),
     execute: async () => {
+      const school = activeSchool();
+      if (!supportsCapability(school, "courseSelection")) {
+        return { error: unsupportedCapabilityMessage(school, "courseSelection") };
+      }
       const result = await inspectXk(config.jwglUsername, config.jwglPassword);
       const okRounds = result.rounds.filter((r) => r.status === "ok");
       return {

--- a/src/tools/grades.ts
+++ b/src/tools/grades.ts
@@ -6,11 +6,12 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { summarizeAcademics, summarizeGeneralElectives } from "../academic-summary";
-import { config } from "../config";
-import { fetchExamsSmart, parseSemesterString } from "../jwgl/academics";
-import { fetchAllGrades } from "../jwgl/grades";
+import { parseSemesterString } from "../jwgl/academics";
 import { fetchLabGradesSmart } from "../jwgl/portal";
-import { getCookie } from "./session";
+import { probeExams } from "../schools/probe";
+import { activeSchool } from "../schools/registry";
+import { supportsCapability, unsupportedCapabilityMessage } from "../schools/types";
+import { getCookie, getSession, schoolSessionFor } from "./session";
 
 export const gradesTools = {
   /** 成绩查询 */
@@ -19,10 +20,16 @@ export const gradesTools = {
       "查询全部学期的成绩与 GPA、已获学分、未通过/待确认课程及通识分类概览。重复课程取最高有效成绩；只统计已通过课程的学分，不代替培养方案或毕业审核。",
     inputSchema: z.object({}),
     execute: async () => {
-      const cookie = await getCookie();
-      const result = await fetchAllGrades(cookie, config.jwglUsername);
+      const ctx = await schoolSessionFor("grades");
+      if ("error" in ctx) return ctx;
+      const result = await ctx.school.fetchGrades(ctx.session);
 
-      const generalElectives = summarizeGeneralElectives(result.allCourses);
+      // 通识六类统计依赖成绩里的「课程归属」字段，不是每所学校都给。
+      // 缺该能力时整个字段不返回——否则模型会拿一张空表说「你六类一门都没修」，
+      // 而事实是「这所学校的接口没提供分类数据」。
+      const generalElectives = supportsCapability(ctx.school, "generalElectives")
+        ? summarizeGeneralElectives(result.allCourses)
+        : undefined;
 
       return {
         gpa: result.gpa,
@@ -62,8 +69,13 @@ export const gradesTools = {
       if (semester && !parsed) {
         return { error: `学期格式无法解析：「${semester}」，应为「2026-2027-1」这类格式` };
       }
-      const cookie = await getCookie();
-      const r = await fetchExamsSmart(cookie, parsed?.year, parsed?.semester);
+      const ctx = await schoolSessionFor("exams");
+      if ("error" in ctx) return ctx;
+      const r = await probeExams(ctx.school, ctx.session, {
+        year: parsed?.year,
+        semester: parsed?.semester,
+        refresh: () => getSession(true),
+      });
       if (!r.ok) {
         return { error: `考试查询失败：${r.error}（不是「暂无考试」，是没查到）` };
       }
@@ -97,6 +109,10 @@ export const gradesTools = {
       const parsed = semester ? parseSemesterString(semester) : null;
       if (semester && !parsed) {
         return { error: `学期格式无法解析：「${semester}」，应为「2026-2027-1」这类格式` };
+      }
+      const school = activeSchool();
+      if (!supportsCapability(school, "labGrades")) {
+        return { error: unsupportedCapabilityMessage(school, "labGrades") };
       }
       const cookie = await getCookie();
       const { label, items } = await fetchLabGradesSmart(cookie, parsed?.year, parsed?.semester);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,8 +1,9 @@
 /**
  * CourseRaptor agent 工具集（聚合层）
- * 28 个工具按领域拆分到独立模块，本文件只负责合并与抢课开关过滤。
+ * 30 个工具按领域拆分到独立模块，本文件只负责合并与抢课开关过滤。
  *
  * 模块划分：
+ * - school.ts          当前学校与能力清单 / 二次认证验证码（2）
  * - schedule.ts        课表 / 校历（2）
  * - grades.ts          成绩 / 考试 / 实验成绩（3）
  * - student.ts         学籍 / 已选 / 重修（3）
@@ -25,11 +26,13 @@ import { gradesTools } from "./grades";
 import { memoryTools } from "./memory";
 import { newsTools } from "./news";
 import { scheduleTools } from "./schedule";
+import { schoolTools } from "./school";
 import { studentTools } from "./student";
 import { timeTools } from "./time";
 import { weatherTools } from "./weather";
 
 const raptorToolsAll = {
+  ...schoolTools,
   ...courseSelectionTools,
   ...scheduleTools,
   ...gradesTools,

--- a/src/tools/news.ts
+++ b/src/tools/news.ts
@@ -9,6 +9,35 @@ import { fetchAttachment } from "../attachments";
 import { config } from "../config";
 import { fetchJwcArticle, fetchJwcNews } from "../jwgl/news";
 import { loadUserGrade } from "../memory/longterm";
+import { activeSchool } from "../schools/registry";
+import {
+  type SchoolCapability,
+  supportsCapability,
+  unsupportedCapabilityMessage,
+} from "../schools/types";
+
+/** 能力门禁：本校没接这块就先直说，不白跑一次对外的抓取 */
+function gate(capability: SchoolCapability) {
+  const school = activeSchool();
+  return supportsCapability(school, capability)
+    ? null
+    : { error: unsupportedCapabilityMessage(school, capability) };
+}
+
+/**
+ * 本校官网域名（read_notice / fetch_attachment 的白名单）。
+ * 白名单必须按学校取：把 A 校域名写死，B 校用户贴出自己学校的通知链接就会被拒。
+ */
+function schoolArticleHosts(): string[] {
+  return activeSchool().newsDomains;
+}
+
+/** URL 是否属于本校官网（含子域） */
+function isSchoolArticleUrl(url: string): boolean {
+  return schoolArticleHosts().some((domain) =>
+    new RegExp(`^https?://[a-z0-9.-]*\\.?${domain.replace(/\./g, "\\.")}/`, "i").test(url),
+  );
+}
 
 // ── 通知相关性 ────────────────────────────────────────────────
 // 教务处一次发十几条，其中大半跟具体某个学生无关。过去全靠模型逐条判断，
@@ -98,6 +127,8 @@ export const newsTools = {
       limit: z.number().int().min(1).max(30).default(10).describe("返回条数（默认 10）"),
     }),
     execute: async ({ category, limit }) => {
+      const blocked = gate("news");
+      if (blocked) return blocked;
       const items = await fetchJwcNews([], 30);
       const filtered = category ? items.filter((i) => i.category === category) : items;
       const grade = await loadUserGrade();
@@ -138,8 +169,12 @@ export const newsTools = {
       url: z.string().describe("文章页 URL（jwc.njtech.edu.cn 或其他 njtech.edu.cn 子域）"),
     }),
     execute: async ({ url }) => {
-      if (!/^https?:\/\/[a-z0-9.-]*\.njtech\.edu\.cn\//.test(url)) {
-        return { error: "仅支持 njtech.edu.cn 域名下的文章 URL" };
+      const blocked = gate("notice");
+      if (blocked) return blocked;
+      if (!isSchoolArticleUrl(url)) {
+        return {
+          error: `仅支持${activeSchool().name}官网域名（${schoolArticleHosts().join(" / ")}）下的文章 URL`,
+        };
       }
       try {
         const article = await fetchJwcArticle(url);
@@ -187,10 +222,12 @@ export const newsTools = {
       refresh: z.boolean().optional().describe("忽略缓存强制重新下载（默认用缓存）"),
     }),
     execute: async ({ url, name, offset, limit, keyword, refresh }) => {
-      const isNjtech = /^https?:\/\/[a-z0-9.-]*\.njtech\.edu\.cn\//.test(url);
-      if (!isNjtech && !config.firecrawlApiKey) {
+      const fromSchoolSite = isSchoolArticleUrl(url);
+      if (!fromSchoolSite && !config.firecrawlApiKey) {
         return {
-          error: "仅支持 njtech.edu.cn 域名的附件（未配置 FIRECRAWL_API_KEY 时）",
+          error:
+            `非${activeSchool().name}官网（${schoolArticleHosts().join(" / ")}）的附件需要配置 FIRECRAWL_API_KEY 才能解析下载，` +
+            `或直接把文件内容发进对话`,
         };
       }
       try {

--- a/src/tools/schedule.ts
+++ b/src/tools/schedule.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
 import {
   buildWeekIndex,
   currentWeekOf,
-  fetchScheduleSmart,
   parseSemesterString,
   periodTimeRange,
   resolveWeek1Monday,
@@ -23,7 +22,9 @@ import {
   specialOnDate,
 } from "../jwgl/term-holidays";
 import { saveScheduleCache } from "../schedule-cache";
-import { getCookie } from "./session";
+import { probeSchedule } from "../schools/probe";
+import { supportsCapability } from "../schools/types";
+import { getSession, schoolSessionFor } from "./session";
 
 export const scheduleTools = {
   /** 课表查询 */
@@ -41,8 +42,13 @@ export const scheduleTools = {
       if (semester && !parsed) {
         return { error: `学期格式无法解析：「${semester}」，应为「2026-2027-1」这类格式` };
       }
-      const cookie = await getCookie();
-      const r = await fetchScheduleSmart(cookie, parsed?.year, parsed?.semester);
+      const ctx = await schoolSessionFor("schedule");
+      if ("error" in ctx) return ctx;
+      const r = await probeSchedule(ctx.school, ctx.session, {
+        year: parsed?.year,
+        semester: parsed?.semester,
+        refresh: () => getSession(true),
+      });
       // 拿不到 ≠ 没有：断网/会话失效必须如实说，不能让用户以为这学期没课
       if (!r.ok) {
         return {
@@ -98,7 +104,9 @@ export const scheduleTools = {
         // 去查通知，而不是让它拿校历或印象回答「国庆放几天」这类问题
         specialDaysNote: specialDays.length
           ? undefined
-          : "尚无放假/调休落盘记录。法定节假日（国庆/元旦/清明/五一/端午/中秋/寒暑假）的具体安排以教务处通知为准：用户问放假安排、或问的课表周临近节假日时，先 get_news 查「放假/调休」相关通知，读到就 read_notice + set_holidays 落盘；查无通知再按「按国务院文件执行、另行通知」回答。",
+          : supportsCapability(ctx.school, "news")
+            ? "尚无放假/调休落盘记录。法定节假日（国庆/元旦/清明/五一/端午/中秋/寒暑假）的具体安排以教务处通知为准：用户问放假安排、或问的课表周临近节假日时，先 get_news 查「放假/调休」相关通知，读到就 read_notice + set_holidays 落盘；查无通知再按「按国务院文件执行、另行通知」回答。"
+            : `尚无放假/调休落盘记录，且${ctx.school.name}未接入教务通知接口，查不到官方安排。用户问放假/调休时，请他直接把学校通知原文发过来（或给可访问的通知页链接），读到后用 set_holidays 落盘；没有原文就如实说「学校没开放接口，我不猜具体日期」。`,
         todaySpecial: today ? { date: todayIso, ...today } : undefined,
         note:
           term.courses.length === 0 ? "课表已查通但无排课（假期或学期未排课属正常）" : undefined,

--- a/src/tools/school.ts
+++ b/src/tools/school.ts
@@ -1,0 +1,114 @@
+/**
+ * 学校与认证状态工具：get_school_status / submit_auth_code
+ *
+ * 为什么需要这两个：
+ * - 多校以后「你现在服务哪所学校、这所学校能查什么」是模型必须知道的事实。
+ *   没有这个工具，模型只能背提示词；提示词与适配器能力表一旦不同步就会说错。
+ * - 河北农大统一认证会在账密之后再要一个动态码。对话式 agent 拿不到用户手机，
+ *   只能走「工具报需要验证码 → 模型向用户索要 → 用户回验证码 → 本工具续完登录」。
+ *   这一步没有专门工具的话，登录会永远卡在第一次调用上。
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+
+import { config } from "../config";
+import { findSecondFactor } from "../schools/mfa";
+import { activeSchool, allSchools } from "../schools/registry";
+import { CAPABILITY_LABELS, type SchoolCapability } from "../schools/types";
+import { invalidateSession, submitAuthCode } from "./session";
+
+/** 全部能力键。由标签表反推，保证清单与门禁话术同源 */
+const ALL_CAPABILITIES = Object.keys(CAPABILITY_LABELS) as SchoolCapability[];
+
+export const schoolTools = {
+  /** 当前学校与能力清单 */
+  get_school_status: tool({
+    description:
+      "查询当前服务的学校、教务入口、所在城市，以及这所学校已接入/未接入的能力清单（可选传 school 查其他学校的配置）。多校以后任何「你能不能查××」的问题都以本工具返回为准，不要凭印象回答——能力按学校划分，换学校就换了一批能力。",
+    inputSchema: z.object({
+      school: z
+        .string()
+        .optional()
+        .describe("要查看的学校 id（如 njtech / hebau）；不填查当前生效的学校"),
+    }),
+    execute: async ({ school }) => {
+      const active = activeSchool();
+      const target = school ? allSchools().find((s) => s.id === school) : active;
+      if (!target) {
+        return {
+          error: `没有 id 为「${school}」的学校。可选：${allSchools()
+            .map((s) => `${s.id}（${s.name}）`)
+            .join("、")}`,
+        };
+      }
+      const unsupported = ALL_CAPABILITIES.filter((cap) => !target.capabilities.includes(cap));
+      return {
+        school: target.id,
+        name: target.name,
+        active: target.id === active.id,
+        city: target.city,
+        jwglBase: target.jwglBase,
+        gpaBasis: target.gpaBasis,
+        secondFactor: target.supportsSecondFactor ? "可能要求动态码二次认证" : "不需要二次认证",
+        supported: target.capabilities.map((cap) => CAPABILITY_LABELS[cap]),
+        unsupported: unsupported.map((cap) => CAPABILITY_LABELS[cap]),
+        credentials:
+          target.id === active.id
+            ? config.jwglUsername && config.jwglPassword
+              ? `已配置学号 ${config.jwglUsername}（来源 ${config.credentialsSource}）`
+              : "未配置：按启动引导录入，或在 .env 设置 JWGL_USERNAME / JWGL_PASSWORD"
+            : "（非当前生效学校，不检查凭证）",
+      };
+    },
+  }),
+
+  /** 提交二次认证验证码 */
+  submit_auth_code: tool({
+    description:
+      "提交学校统一认证的动态验证码，完成被二次认证打断的登录。只在其他教务工具返回「需要二次认证」之后调用：先向用户索要手机/邮箱收到的验证码原文，拿到码再调本工具。challenge_id 可省略（系统按当前学校+当前学号找待验证会话）。码对上了登录即完成，之后重试刚才那个查询即可。",
+    inputSchema: z.object({
+      code: z.string().describe("用户发来的验证码数字串"),
+      challenge_id: z
+        .string()
+        .optional()
+        .describe("待验证会话 ID。省略时自动用当前学校+学号最新的那一条"),
+    }),
+    execute: async ({ code, challenge_id }) => {
+      const school = activeSchool();
+      if (!school.supportsSecondFactor) {
+        return {
+          error: `${school.name}的教务登录不要求二次认证。如果是别的原因登录失败，按错误信息处理，不要调本工具。`,
+        };
+      }
+      const digits = code.replace(/\D/g, "");
+      if (!digits) {
+        return {
+          error: "没收到验证码数字。请把手机/邮箱里收到的验证码原样发给我（例如「483920」）。",
+        };
+      }
+      const pending = challenge_id ? null : findSecondFactor(school.id, config.jwglUsername);
+      const id = challenge_id ?? pending?.challengeId;
+      if (!id) {
+        return {
+          error:
+            "当前没有等待验证码的登录会话（可能已过期或已用完）。先重新查一次课表/成绩触发登录，拿到新的验证码再提交。",
+        };
+      }
+
+      // 上一轮的失败会话不能留着：否则用户以为还能用旧码重试
+      invalidateSession();
+      try {
+        const session = await submitAuthCode(id, digits);
+        return {
+          ok: true,
+          school: school.name,
+          username: session.username,
+          note: "登录已完成。请立刻重试刚才那个查询（课表/成绩/考试），不必再让用户提供账号。",
+        };
+      } catch (e) {
+        return { error: `验证码提交失败：${(e as Error).message}` };
+      }
+    },
+  }),
+};

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -1,32 +1,54 @@
 /**
- * 共享会话管理：教务登录 cookie 与选课会话的缓存 + 失效重建
+ * 共享会话管理：教务登录会话的缓存 + 失效重建
  * 教务线路间歇抖动，全部带指数退避重试
+ *
+ * 学校维度：登录一律走 activeSchool() 的适配器，本文件不认识具体学校。
+ * 缓存单位是 SchoolSession（cookie + 学号）而不是裸 cookie——河北农大的抓取接口
+ * 要用学号推入学年份，且 CAS 会话由多个 Cookie 项拼成，拆开存迟早漏一个。
  */
 
 import { config } from "../config";
-import { loginJwgl } from "../jwgl/auth";
 import { openXkSession, type XkSession } from "../jwgl/xk";
+import { SecondFactorRequiredError } from "../schools/mfa";
+import { activeSchool } from "../schools/registry";
+import {
+  type SchoolAdapter,
+  type SchoolCapability,
+  type SchoolSession,
+  supportsCapability,
+  unsupportedCapabilityMessage,
+} from "../schools/types";
 
 const RETRY_MAX = 5;
 
-// ── 普通登录 cookie（课表/成绩/考试用）────────────────────────
+// ── 普通登录会话（课表/成绩/考试用）───────────────────────────
 
 interface AuthCache {
-  cookie: string;
+  session: SchoolSession;
   createdAt: number;
 }
 
 let authCache: AuthCache | null = null;
 const AUTH_TTL_MS = 25 * 60 * 1000; // 25 分钟（保守于 30 分钟会话）
 
+/** 获取登录会话（缓存复用，失效/被强制时重建） */
+export async function getSession(force = false): Promise<SchoolSession> {
+  if (!force && authCache && Date.now() - authCache.createdAt < AUTH_TTL_MS) {
+    return authCache.session;
+  }
+  const session = await loginWithRetry();
+  authCache = { session, createdAt: Date.now() };
+  return session;
+}
+
 /** 获取登录 cookie（缓存复用，失效/被强制时重建） */
 export async function getCookie(force = false): Promise<string> {
-  if (!force && authCache && Date.now() - authCache.createdAt < AUTH_TTL_MS) {
-    return authCache.cookie;
-  }
-  const { cookie } = await loginWithRetry();
-  authCache = { cookie, createdAt: Date.now() };
-  return cookie;
+  return (await getSession(force)).cookie;
+}
+
+/** 会话被判失效时清缓存，下一轮重新登录 */
+export function invalidateSession(): void {
+  authCache = null;
 }
 
 // ── 选课会话（含 xkkzId/csrftoken 与预热上下文）─────────────────
@@ -56,14 +78,18 @@ export function invalidateXkSession(): void {
 
 // ── 带重试的登录 ─────────────────────────────────────────────
 
-async function loginWithRetry(): Promise<{ cookie: string }> {
+async function loginWithRetry(): Promise<SchoolSession> {
+  const school = activeSchool();
+  requireCredentials(school.name);
   let lastError: Error | null = null;
   for (let attempt = 1; attempt <= RETRY_MAX; attempt++) {
     try {
-      return await loginJwgl(config.jwglUsername, config.jwglPassword);
+      return await school.login({ username: config.jwglUsername, password: config.jwglPassword });
     } catch (e) {
       lastError = e as Error;
       const msg = lastError.message;
+      // 二次认证要的是用户手里的验证码，不是第 2 次登录：重试等于反复给用户手机发码
+      if (lastError instanceof SecondFactorRequiredError) throw lastError;
       // 密码错误不需要重试
       if (msg.includes("密码") || msg.includes("学号")) throw lastError;
       if (attempt < RETRY_MAX) {
@@ -74,7 +100,80 @@ async function loginWithRetry(): Promise<{ cookie: string }> {
   throw new Error(`教务登录失败（已重试 ${RETRY_MAX} 次）：${lastError?.message ?? "未知错误"}`);
 }
 
+/** 凭证缺失的前置拦截。空账号去打登录接口只会换来一句「密码错误」，误导人 */
+function requireCredentials(schoolName: string): void {
+  if (config.jwglUsername && config.jwglPassword) return;
+  throw new Error(
+    `尚未配置${schoolName}的教务系统账号。运行 raptor 按引导录入，或在 .env 设置 JWGL_USERNAME / JWGL_PASSWORD（换学校时记得换成本校账号）。`,
+  );
+}
+
+/**
+ * 把「需要二次认证」翻译成工具返回值。
+ * 抛给 SDK 只剩一句模糊的工具失败，模型会当成网络问题转述；
+ * 结构化字段（needs_auth_code / challenge_id）才能让它明确去要验证码。
+ */
+export function secondFactorGate(
+  error: unknown,
+): { error: string; needs_auth_code: true; challenge_id: string } | null {
+  if (!(error instanceof SecondFactorRequiredError)) return null;
+  return {
+    error: error.message,
+    needs_auth_code: true,
+    challenge_id: error.challengeId,
+  };
+}
+
+/**
+ * 教务工具的统一入口：能力门禁 → 取会话 → 拦住二次认证。
+ *
+ * 顺序很重要：先判能力再登录。河北农大没开放选课接口，若先登录再拒绝，
+ * 用户会平白收到一条 CAS 验证码。
+ */
+export async function schoolSessionFor(
+  capability: SchoolCapability,
+): Promise<
+  | { school: SchoolAdapter; session: SchoolSession }
+  | { error: string; unsupported?: boolean; needs_auth_code?: boolean; challenge_id?: string }
+> {
+  const school = activeSchool();
+  if (!supportsCapability(school, capability)) {
+    return { error: unsupportedCapabilityMessage(school, capability), unsupported: true };
+  }
+  try {
+    return { school, session: await getSession() };
+  } catch (e) {
+    const gate = secondFactorGate(e);
+    if (gate) return gate;
+    throw e;
+  }
+}
+
+/**
+ * 用用户提供的验证码完成二次认证。
+ * 成功即写入会话缓存，之后同一轮里的查询不必再登录一次。
+ */
+export async function submitAuthCode(challengeId: string, code: string): Promise<SchoolSession> {
+  const school = activeSchool();
+  requireCredentials(school.name);
+  const session = await school.login({
+    username: config.jwglUsername,
+    password: config.jwglPassword,
+    challengeId,
+    dynamicCode: code,
+  });
+  authCache = { session, createdAt: Date.now() };
+  return session;
+}
+
 async function openXkSessionWithRetry(): Promise<XkSession> {
+  // 选课模块（src/jwgl/xk.ts）只对接了南工大教务系统。不设这道卡，
+  // 河北农大的用户一触发选课工具，就会拿着河农大的学号密码去登录南工大——
+  // 那是凭证外泄，不是功能缺失。
+  const school = activeSchool();
+  if (!supportsCapability(school, "courseSelection")) {
+    throw new Error(unsupportedCapabilityMessage(school, "courseSelection"));
+  }
   let lastError: Error | null = null;
   for (let attempt = 1; attempt <= RETRY_MAX; attempt++) {
     try {

--- a/src/tools/student.ts
+++ b/src/tools/student.ts
@@ -5,7 +5,24 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { fetchEnrolledClasses, fetchProfile, fetchRetakeCourses } from "../jwgl/portal";
+import { activeSchool } from "../schools/registry";
+import {
+  type SchoolCapability,
+  supportsCapability,
+  unsupportedCapabilityMessage,
+} from "../schools/types";
 import { getCookie } from "./session";
+
+/**
+ * 能力门禁。这三块河北农大 URP 没有对应端点，取不到就必须直说「本校未接入」，
+ * 绝不去撞南工大的接口——那等于把 A 校的数据当成 B 校的答案。
+ */
+function gate(capability: SchoolCapability) {
+  const school = activeSchool();
+  return supportsCapability(school, capability)
+    ? null
+    : { error: unsupportedCapabilityMessage(school, capability) };
+}
 
 export const studentTools = {
   /** 学籍个人信息 */
@@ -14,6 +31,8 @@ export const studentTools = {
       "查询学籍个人信息：姓名、学号、性别、学院、专业、班级、年级、学制、入学/毕业日期等（从教务系统个人信息页解析）。需要确认用户身份信息、或查询班级/专业信息时调用。",
     inputSchema: z.object({}),
     execute: async () => {
+      const blocked = gate("student");
+      if (blocked) return blocked;
       const cookie = await getCookie();
       const profile = await fetchProfile(cookie);
       // 敏感字段打码（只留前4后4），避免完整证件/卡号进入模型上下文
@@ -44,6 +63,8 @@ export const studentTools = {
       "查询本学期已选的课程教学班列表：课程名、教学班、教师、上课时间、地点、学分、课程性质（必修/选修）。注意：与课表（get_schedule）互补，这里按教学班维度、含选课属性。",
     inputSchema: z.object({}),
     execute: async () => {
+      const blocked = gate("enrolledCourses");
+      if (blocked) return blocked;
       const cookie = await getCookie();
       const classes = await fetchEnrolledClasses(cookie);
       return {
@@ -62,6 +83,8 @@ export const studentTools = {
       keyword: z.string().optional().describe("课程名关键词过滤（可选）"),
     }),
     execute: async ({ keyword }) => {
+      const blocked = gate("retakeCourses");
+      if (blocked) return blocked;
       const cookie = await getCookie();
       const all = await fetchRetakeCourses(cookie);
       const filtered = keyword ? all.filter((c) => c.courseName.includes(keyword)) : all;

--- a/src/tui/welcome.ts
+++ b/src/tui/welcome.ts
@@ -7,7 +7,6 @@
 
 import {
   expandWeeks,
-  fetchScheduleSmart,
   periodTimeRange,
   type ScheduleResult,
   WEEKDAY_NAMES,
@@ -15,7 +14,10 @@ import {
 import { fetchJwcNews } from "../jwgl/news";
 import { currentWeekOf } from "../jwgl/term-dates";
 import { loadScheduleCache, saveScheduleCache } from "../schedule-cache";
-import { getCookie } from "../tools/session";
+import { probeSchedule } from "../schools/probe";
+import { activeSchool } from "../schools/registry";
+import { supportsCapability } from "../schools/types";
+import { getSession } from "../tools/session";
 import { startChatWeb } from "../web/chat-web";
 
 declare global {
@@ -80,6 +82,12 @@ async function refreshWebUrl() {
 }
 
 async function refreshNews() {
+  const school = activeSchool();
+  if (!supportsCapability(school, "news")) {
+    panel.newsLines = [dim(`  ${school.name}尚未接入教务通知，可直接把通知原文发给我`)];
+    render();
+    return;
+  }
   try {
     const news = await fetchJwcNews([], 3);
     panel.newsLines = news.length
@@ -99,9 +107,17 @@ async function refreshSchedule() {
     renderSchedule(cached.schedule);
     return;
   }
+  const school = activeSchool();
+  // 需要二次认证的学校（如河农大 CAS）不在启动面板里悄悄登录：
+  // 那会平白往用户手机上发一条验证码。这类学校只等用户主动问一次课表。
+  if (!supportsCapability(school, "schedule") || school.supportsSecondFactor) {
+    panel.scheduleLines = [dim("  直接问「今天课表」即可加载")];
+    render();
+    return;
+  }
   try {
-    const cookie = await getCookie();
-    const r = await fetchScheduleSmart(cookie);
+    const session = await getSession();
+    const r = await probeSchedule(school, session);
     if (!r.ok) {
       panel.scheduleLines = [dim("  课表获取失败，可直接问我查详情")];
       render();

--- a/src/weather.ts
+++ b/src/weather.ts
@@ -17,8 +17,8 @@
  *    注入，坏网/超时/查无此城的分支都不用联网也能测。
  */
 
-import { BASE as JWGL_BASE } from "./jwgl/auth";
 import type { FetchResult } from "./jwgl/http";
+import { activeSchool } from "./schools/registry";
 
 const GEO_URL = "https://geocoding-api.open-meteo.com/v1/search";
 const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
@@ -45,16 +45,20 @@ const httpFetch: WeatherFetch = async (url, init) => {
 
 // ── 默认城市：按学校判断 ──────────────────────────────────────
 // 本 agent 服务哪所学校，默认就查哪座城市。键是教务系统主机名，
-// 以后多接一所学校（如 ScholarFlow 侧的 HEBau）在这里加一行。
+// 新增学校时在适配器里写 city 即可，这里只兜「显式传入别的 base」的场合。
 
 const SCHOOL_CITY: Record<string, string> = {
   "jwgl.njtech.edu.cn": "南京", // 南京工业大学浦口校区
+  "urp.hebau.edu.cn": "保定", // 河北农业大学（教务在 1009 端口，剥掉端口再查）
 };
 
-/** 学校所在城市。主机名没登记时仍退回南京——当前只有 NJTECH 一套教务 */
-export function defaultWeatherCity(jwglBase: string = JWGL_BASE): string {
-  const host = jwglBase.replace(/^https?:\/\//, "").split("/")[0];
-  return SCHOOL_CITY[host] ?? "南京";
+/** 学校所在城市。主机名没登记时退回当前学校的城市 */
+export function defaultWeatherCity(jwglBase: string = activeSchool().jwglBase): string {
+  const host = jwglBase
+    .replace(/^https?:\/\//, "")
+    .split("/")[0]
+    .split(":")[0];
+  return SCHOOL_CITY[host] ?? activeSchool().city;
 }
 
 // ── WMO 天气码 → 中文 ─────────────────────────────────────────

--- a/tests/hebau-adapter.test.ts
+++ b/tests/hebau-adapter.test.ts
@@ -1,0 +1,352 @@
+/**
+ * 河北农大适配器的离线单测：只测纯逻辑与配置隔离，绝不打真实教务系统。
+ *
+ * 三件必须钉住的事：
+ * 1. 行归一（URP 字段名大小写混杂、周次带「周」字、节次给区间）；
+ * 2. 5.0 绩点口径：通过型/缓考不参与计算（返回 null），不是 0 分；
+ * 3. 多校隔离：候选学期探测在与南工大旧实现上逐月等价；换校后能力门禁生效；
+ *    凭证属于另一所学校时不得被采用（那是凭证外泄路径）。
+ */
+
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+import { config } from "../src/config";
+import { candidateXnxqList } from "../src/jwgl/academics";
+import { resolveWeek1Monday } from "../src/jwgl/term-dates";
+import type { GradeCourse } from "../src/jwgl/types";
+import { encryptPassword } from "../src/schools/hebau/cas";
+import { dedupeExams, parseExamDate, toExamRow } from "../src/schools/hebau/exams";
+import {
+  dedupeGrades,
+  hebauGradeToGP,
+  isHebauPassFail,
+  isHebauRequired,
+} from "../src/schools/hebau/grades";
+import { normalizeWeekSpec, parsePeriodRange, toCourseRow } from "../src/schools/hebau/schedule";
+import { extractUrpRows, xnxqdm } from "../src/schools/hebau/urp";
+import { normalizeSchoolId } from "../src/schools/ids";
+import { HEBAU_PERIOD_TIMES, NJTECH_PERIOD_TIMES } from "../src/schools/period-times";
+import { candidateTerms } from "../src/schools/probe";
+import { activeSchool, resetSchoolCache } from "../src/schools/registry";
+import {
+  CAPABILITY_LABELS,
+  supportsCapability,
+  unsupportedCapabilityMessage,
+} from "../src/schools/types";
+
+/** 恢复 config.school，免得一个改过学校的用例污染后面的文件 */
+const originalSchool = config.school;
+after(() => {
+  config.school = originalSchool;
+  resetSchoolCache();
+});
+
+function withSchool<T>(id: string, run: () => T): T {
+  config.school = id;
+  resetSchoolCache();
+  try {
+    return run();
+  } finally {
+    config.school = originalSchool;
+    resetSchoolCache();
+  }
+}
+
+// ── 学期编码与行归一 ─────────────────────────────────────────
+
+test("xnxqdm: 内部学期码（3/12）换算成 URP 的 XNXQDM 字符串", () => {
+  assert.equal(xnxqdm(2026, 3), "2026-2027-1");
+  assert.equal(xnxqdm(2025, 12), "2025-2026-2");
+});
+
+test("课表行归一：小写字段、区间节次、带「周」字的周次都能收正", () => {
+  const row = {
+    kcmc: "高等数学A",
+    xqj: "3",
+    skjc: "1",
+    jsjc: "2",
+    skzc: "1-16周",
+    jasmc: "3教101",
+    skjs: "王老师",
+  };
+  const c = toCourseRow(row);
+  assert.ok(c);
+  assert.equal(c?.title, "高等数学A");
+  assert.equal(c?.weekday, 3);
+  assert.deepEqual(c?.periods, [1, 2]);
+  assert.equal(c?.weeks, "1-16");
+  assert.equal(c?.location, "3教101");
+  assert.equal(c?.teacher, "王老师");
+});
+
+test("课表行归一：课程名为空的统计行丢弃，单节课不被补成两节", () => {
+  assert.equal(toCourseRow({ xqj: "1", skjc: "3" }), null);
+  const single = toCourseRow({ KCMC: "体育", XQJ: "2", SKJC: "5" });
+  assert.deepEqual(single?.periods, [5]);
+});
+
+test("normalizeWeekSpec: 去「周」与空白，保留单双周标记", () => {
+  assert.equal(normalizeWeekSpec("2-6,8-12周"), "2-6,8-12");
+  assert.equal(normalizeWeekSpec("1-20 周"), "1-20");
+  assert.equal(normalizeWeekSpec("3-16周(双)"), "3-16(双)");
+});
+
+test("parsePeriodRange: 只给开始节时按 1 节算，不再默认连堂 2 节", () => {
+  assert.deepEqual(parsePeriodRange({ SKJC: "7" }), [7]);
+  assert.deepEqual(parsePeriodRange({ SKJC: "7", SKCD: "3" }), [7, 8, 9]);
+  assert.deepEqual(parsePeriodRange({}), []);
+});
+
+test("extractUrpRows: 考试接口把行拆成 arranged/notArranged 也要合并取到", () => {
+  const payload = {
+    datas: {
+      queryMyExamArrangeMent: {
+        arranged: [{ KCMC: "A", KSRQ: "2026-06-15" }],
+        notArranged: [{ KCMC: "B" }],
+      },
+    },
+  };
+  const rows = extractUrpRows(payload, "queryMyExamArrangeMent");
+  assert.equal(rows?.length, 2);
+  // 结构完全对不上时必须是 null（= 报错），不能是空数组（=「你没有考试」）
+  assert.equal(extractUrpRows({ foo: 1 }, "x"), null);
+});
+
+test("考试行归一：日期与时间同串时拆开，未排期的行保留", () => {
+  const merged = toExamRow({ KCMC: "数据结构", KSSJ: "2026-06-20 08:00-10:00", ZWH: "12" });
+  assert.equal(merged?.date, "2026-06-20");
+  assert.equal(merged?.time, "08:00-10:00");
+  assert.equal(merged?.seatNumber, "12");
+  const unscheduled = toExamRow({ KCMC: "形势政策", KSJC: "待定" });
+  assert.ok(unscheduled);
+  assert.equal(unscheduled?.date, "");
+  assert.equal(toExamRow({ XQBH: "备注行" }), null);
+  assert.equal(parseExamDate({ SJKSRQ: "2026/06/15 上午" }), "2026-06-15");
+});
+
+test("考试去重：同键留信息更全的那条", () => {
+  const deduped = dedupeExams([
+    { subject: "A", date: "2026-06-20", time: "08:00", location: "" },
+    { subject: "A", date: "2026-06-20", time: "08:00", location: "3教101", seatNumber: "5" },
+  ]);
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].location, "3教101");
+});
+
+// ── 成绩口径 ──────────────────────────────────────────────────
+
+test("河北农大 5.0 绩点：百分制折算与等级制映射", () => {
+  assert.equal(hebauGradeToGP("100"), 5);
+  assert.equal(hebauGradeToGP("85"), 3.5);
+  assert.equal(hebauGradeToGP("60"), 1);
+  assert.equal(hebauGradeToGP("59"), 0);
+  assert.equal(hebauGradeToGP("优秀"), 4.5);
+  assert.equal(hebauGradeToGP("及格"), 1.5);
+});
+
+test("通过型与未考标记返回 null（不参与 GPA），与 0 分是两回事", () => {
+  for (const score of ["合格", "通过", "免修", "免考", "缓考", "缺考", ""]) {
+    assert.equal(hebauGradeToGP(score), null, score);
+  }
+  assert.equal(hebauGradeToGP("不及格"), 0);
+  assert.equal(isHebauPassFail("合格"), true);
+  assert.equal(isHebauPassFail("中等"), false);
+});
+
+test("必修判定认 URP 的性质代码 001，也认中文", () => {
+  assert.equal(isHebauRequired("001"), true);
+  assert.equal(isHebauRequired("必修"), true);
+  assert.equal(isHebauRequired("专业选修"), false);
+});
+
+test("重修去重按「课程号+性质」，多学期同名课不被合并吞学分", () => {
+  const courses: GradeCourse[] = [
+    {
+      course: "大学英语1",
+      courseCode: "A01",
+      score: "72",
+      credit: "2",
+      type: "必修",
+      semester: "2024-2025-1",
+    },
+    {
+      course: "大学英语2",
+      courseCode: "A02",
+      score: "80",
+      credit: "2",
+      type: "必修",
+      semester: "2024-2025-2",
+    },
+    {
+      course: "高等数学",
+      courseCode: "B01",
+      score: "55",
+      credit: "4",
+      type: "必修",
+      semester: "2024-2025-1",
+    },
+    {
+      course: "高等数学",
+      courseCode: "B01",
+      score: "78",
+      credit: "4",
+      type: "必修",
+      semester: "2025-2026-1",
+    },
+  ];
+  const deduped = dedupeGrades(courses);
+  assert.equal(deduped.length, 3);
+  assert.ok(deduped.find((g) => g.courseCode === "B01")?.score === "78");
+});
+
+// ── 学校隔离与门禁 ───────────────────────────────────────────
+
+test("候选学期探测：在南工大月份区间上与旧实现逐月等价", () => {
+  for (let month = 1; month <= 12; month++) {
+    const now = new Date(2026, month - 1, 10);
+    assert.deepEqual(
+      candidateTerms([2, 6], now),
+      candidateXnxqList(now),
+      `${month} 月的候选学期与 NJTECH 原实现不一致`,
+    );
+  }
+});
+
+test("候选学期探测：河北农大春夏学期覆盖到 7 月，7 月不提前探秋学期", () => {
+  const july = new Date(2026, 6, 10);
+  assert.deepEqual(candidateTerms([2, 7], july), [
+    { year: 2025, semester: 12 },
+    { year: 2025, semester: 3 },
+  ]);
+  assert.deepEqual(candidateTerms([2, 7], new Date(2026, 7, 10))[0], { year: 2026, semester: 3 });
+});
+
+test("两校节次表不同，且各自的表都完整到第 10 节", () => {
+  assert.equal(NJTECH_PERIOD_TIMES["1"], "08:10-08:55");
+  assert.equal(HEBAU_PERIOD_TIMES["1"], "08:00-08:45");
+  for (const table of [NJTECH_PERIOD_TIMES, HEBAU_PERIOD_TIMES]) {
+    for (let p = 1; p <= 10; p++) assert.ok(table[String(p)], `缺第 ${p} 节`);
+  }
+});
+
+test("RAPTOR_SCHOOL 未知值硬失败，不回退默认学校", () => {
+  assert.equal(normalizeSchoolId(undefined), "njtech");
+  assert.equal(normalizeSchoolId("  HEBau "), "hebau");
+  assert.throws(() => normalizeSchoolId("tsinghua"), /不是已知学校/);
+});
+
+test("河北农大：能力清单只含已接入项，门禁话术说清是「学校没接口」", () => {
+  withSchool("hebau", () => {
+    const school = activeSchool();
+    assert.equal(school.name, "河北农业大学");
+    assert.equal(school.city, "保定");
+    assert.equal(school.supportsSecondFactor, true);
+    assert.equal(supportsCapability(school, "schedule"), true);
+    for (const cap of [
+      "courseSelection",
+      "student",
+      "labGrades",
+      "news",
+      "generalElectives",
+      "retakeCourses",
+      "enrolledCourses",
+    ] as const) {
+      assert.equal(supportsCapability(school, cap), false, `${cap} 不该被声明为已支持`);
+    }
+    const msg = unsupportedCapabilityMessage(school, "courseSelection");
+    assert.match(msg, /河北农业大学/);
+    assert.match(msg, /没有提供对应接口/);
+    assert.match(school.promptFacts, /submit_auth_code/);
+  });
+});
+
+test("南工大：全部能力在册，提示词带上本校教务形态与校历", () => {
+  const school = activeSchool();
+  assert.equal(school.name, "南京工业大学");
+  assert.equal(school.supportsSecondFactor, false);
+  for (const cap of Object.keys(CAPABILITY_LABELS) as (keyof typeof CAPABILITY_LABELS)[]) {
+    assert.equal(supportsCapability(school, cap as never), true, `NJTECH 缺能力 ${cap}`);
+  }
+  assert.match(school.promptFacts, /自主选课/);
+  assert.match(school.promptFacts, /第 1 周 2026-08-31/);
+});
+
+test("校历按学校分开取：同一学期两所学校开学日不同，绝不共用一份真值", () => {
+  const njtech = resolveWeek1Monday(2026, 3, "njtech");
+  assert.equal(njtech.week1Monday, "2026-08-31");
+  assert.match(njtech.evidence ?? "", /南工教〔2026〕91号/);
+  const hebau = resolveWeek1Monday(2026, 3, "hebau");
+  assert.equal(hebau.week1Monday, "2026-09-01");
+  assert.notEqual(hebau.week1Monday, njtech.week1Monday);
+});
+
+test("河北农大课表请求：XNXQDM 正确编码，空数据不当失败", async () => {
+  // 走真实解析链路，但把传输层换成假响应（见 hebau-cas-mfa.test.ts 的同款做法）
+  const { setTransportForTest } = await import("../src/schools/hebau/http");
+  const { fetchHebauSchedule } = await import("../src/schools/hebau/schedule");
+  const seen: string[] = [];
+  setTransportForTest(async (url, opts) => {
+    seen.push(`${url}|${opts.body ?? ""}`);
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        datas: {
+          cxxszhxqkb: {
+            rows: [
+              {
+                KCMC: "作物育种学",
+                XQJ: "2",
+                SKJC: "3",
+                JSJC: "4",
+                SKZC: "1-12周",
+                JASMC: "A305",
+                SKJS: "李老师",
+              },
+            ],
+          },
+        },
+      }),
+    };
+  });
+  try {
+    const r = await fetchHebauSchedule("GS_SESSIONID=x", 2026, 3);
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.equal(r.data[0]?.title, "作物育种学");
+    assert.deepEqual(r.data[0]?.periods, [3, 4]);
+    assert.match(seen[0] ?? "", /XNXQDM=2026-2027-1/);
+  } finally {
+    setTransportForTest(null);
+  }
+});
+
+test("教务系统返回 HTML 登录页时报「会话失效」，不报「没课」", async () => {
+  const { setTransportForTest } = await import("../src/schools/hebau/http");
+  const { fetchHebauSchedule } = await import("../src/schools/hebau/schedule");
+  setTransportForTest(async () => ({
+    status: 200,
+    headers: {},
+    body: "<!DOCTYPE html><html><body>统一认证</body></html>",
+  }));
+  try {
+    const r = await fetchHebauSchedule("c", 2026, 3);
+    assert.equal(r.ok, false);
+    if (r.ok) return;
+    assert.match(r.error, /页面而非数据/);
+    assert.match(r.error, /会话已失效/);
+  } finally {
+    setTransportForTest(null);
+  }
+});
+
+test("密码加密：输出为纯密文 base64，盐长非法时不提交登录", () => {
+  const cipher = encryptPassword("mypassword", "0123456789abcdef");
+  const bytes = Buffer.from(cipher, "base64");
+  assert.equal(bytes.length % 16, 0, "AES-CBC 密文必须是整块");
+  assert.ok(bytes.length >= 80, "64 位随机前缀 + 明文至少两个块");
+  // 每次的随机前缀与 IV 都不同，所以同一密码两次结果必然不同
+  assert.notEqual(cipher, encryptPassword("mypassword", "0123456789abcdef"));
+  assert.throws(() => encryptPassword("x", "tooshort"), /加密参数异常/);
+});

--- a/tests/hebau-mfa.test.ts
+++ b/tests/hebau-mfa.test.ts
@@ -1,0 +1,214 @@
+/**
+ * 河北农大 CAS 登录与二次认证的离线用例（传输层注入假响应，不碰真实教务系统）
+ *
+ * 这里要钉住的都是「错了就伤到用户」的路径：
+ * - 密码错误不能被当成「需要验证码」，更不能反复发码；
+ * - 待验证会话必须按「学校+学号」隔离，别人拿不到我的登录态；
+ * - 会话 10 分钟过期、用完即删；
+ * - 换学校后旧凭证不予采用（凭证串校是安全事故，不是小瑕疵）。
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { before, test } from "node:test";
+
+import { completeSecondFactor, loginHebau } from "../src/schools/hebau/cas";
+import {
+  type RawResponse,
+  type RequestOptions,
+  setTransportForTest,
+} from "../src/schools/hebau/http";
+import {
+  clearAllSecondFactors,
+  findSecondFactor,
+  readSecondFactor,
+  SecondFactorRequiredError,
+} from "../src/schools/mfa";
+
+const LOGIN_PAGE =
+  '<form><input name="execution" value="EX1"/><input id="pwdEncryptSalt" value="0123456789abcdef"/></form>';
+const REAUTH_PAGE = '{"reAuthType":"3","isMultifactor":"true"} <input value="手机(138****1234)"/>';
+
+interface Script {
+  reauth?: boolean;
+  reAuthType?: string;
+  wrongPassword?: boolean;
+  sendFail?: boolean;
+  submitFail?: boolean;
+  noSession?: boolean;
+}
+
+const calls: string[] = [];
+
+function installCas(script: Script): void {
+  calls.length = 0;
+  let loginPageServed = 0;
+  setTransportForTest(async (url, opts: RequestOptions): Promise<RawResponse> => {
+    calls.push(`${opts.method ?? "GET"} ${url}`);
+    const cookie = (name: string) => ({ "set-cookie": [`${name}=v1; Path=/`] });
+    if (url.includes("/dynamicCode/getDynamicCodeByReauth")) {
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: script.sendFail
+          ? '{"res":"fail","returnMessage":"发送过于频繁"}'
+          : '{"res":"success"}',
+      };
+    }
+    if (url.includes("/reAuthCheck/reAuthSubmit")) {
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: script.submitFail
+          ? '{"code":"reAuth_error","msg":"验证码不正确"}'
+          : '{"code":"reAuth_success"}',
+      };
+    }
+    if (url.includes("/reAuthCheck/")) {
+      return {
+        status: 200,
+        headers: {},
+        body: REAUTH_PAGE.replace('"reAuthType":"3"', `"reAuthType":"${script.reAuthType ?? "3"}"`),
+      };
+    }
+    if (url.includes("/authserver/login")) {
+      if ((opts.method ?? "GET") !== "GET") {
+        if (script.wrongPassword) return { status: 200, headers: {}, body: LOGIN_PAGE };
+        if (script.reauth) {
+          return {
+            status: 302,
+            headers: {
+              location: "/authserver/reAuthCheck/reAuthLoginView.do?isMultifactor=true",
+              ...cookie("CASTGT"),
+            },
+            body: "",
+          };
+        }
+        return {
+          status: 302,
+          headers: {
+            location: "http://urp.hebau.edu.cn:1009/jwapp/sys/homeapp/index.do",
+            ...cookie("CASTGT"),
+          },
+          body: "",
+        };
+      }
+      // 第一次是取登录页（要 execution / pwdEncryptSalt），之后回访才是取教务会话
+      if (loginPageServed === 0) {
+        loginPageServed++;
+        return { status: 200, headers: {}, body: LOGIN_PAGE };
+      }
+      return {
+        status: 200,
+        headers: script.noSession ? {} : cookie("GS_SESSIONID"),
+        body: "<html>ok</html>",
+      };
+    }
+    return { status: 200, headers: {}, body: "<html>home</html>" };
+  });
+}
+
+before(() => {
+  process.env.RAPTOR_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "raptor-mfa-"));
+});
+
+test("账密直接通过：拿到含 GS_SESSIONID 的会话", async () => {
+  installCas({});
+  clearAllSecondFactors();
+  const session = await loginHebau({ username: "2021010101", password: "pw" });
+  assert.match(session.cookie, /GS_SESSIONID=/);
+  assert.equal(session.username, "2021010101");
+  assert.equal(findSecondFactor("hebau", "2021010101"), null);
+});
+
+test("密码错误：直说密码错误，不发验证码、不建待验证会话", async () => {
+  installCas({ wrongPassword: true });
+  clearAllSecondFactors();
+  await assert.rejects(
+    () => loginHebau({ username: "2021010101", password: "bad" }),
+    /学号或密码不正确/,
+  );
+  assert.equal(calls.filter((c) => c.includes("getDynamicCodeByReauth")).length, 0);
+  assert.equal(findSecondFactor("hebau", "2021010101"), null);
+});
+
+test("触发二次认证：抛出可用信息，会话按学校+学号可查回", async () => {
+  installCas({ reauth: true });
+  clearAllSecondFactors();
+  const err = await loginHebau({ username: "2021010101", password: "pw" }).catch((e) => e);
+  assert.ok(err instanceof SecondFactorRequiredError, "应抛出让对话层索要验证码的信号");
+  assert.match(err.message, /submit_auth_code/);
+  assert.match(err.message, /138\*\*\*\*1234/);
+  const pending = findSecondFactor("hebau", "2021010101");
+  assert.ok(pending);
+  assert.equal(pending.reAuthType, "3");
+  // 别的学号不能借这条会话续登录
+  assert.equal(findSecondFactor("hebau", "2021090909"), null);
+  assert.equal(typeof readSecondFactor(err.challengeId, "hebau", "2021010101"), "object");
+  assert.equal(typeof readSecondFactor(err.challengeId, "njtech", "2021010101"), "string");
+});
+
+test("验证码正确即完成登录并清除会话；验证码错误保留会话可重试", async () => {
+  const script: Script = { reauth: true, submitFail: true };
+  installCas(script);
+  clearAllSecondFactors();
+  const err: SecondFactorRequiredError = await loginHebau({
+    username: "2021010101",
+    password: "pw",
+  }).catch((e) => e);
+
+  await assert.rejects(
+    () => completeSecondFactor(err.challengeId, "000000", "2021010101"),
+    /验证码不正确/,
+  );
+  assert.ok(findSecondFactor("hebau", "2021010101"), "码错时保留会话，用户可直接重发一次");
+
+  script.submitFail = false;
+  const session = await completeSecondFactor(err.challengeId, "483920", "2021010101");
+  assert.match(session.cookie, /GS_SESSIONID=/);
+  assert.equal(findSecondFactor("hebau", "2021010101"), null, "用完即删");
+});
+
+test("发送验证码失败：如实报错，不留半个待验证会话", async () => {
+  installCas({ reauth: true, sendFail: true });
+  clearAllSecondFactors();
+  await assert.rejects(
+    () => loginHebau({ username: "2021010101", password: "pw" }),
+    /发送过于频繁/,
+  );
+  assert.equal(findSecondFactor("hebau", "2021010101"), null);
+});
+
+test("未登记的认证方式：说清不支持，不发码", async () => {
+  installCas({ reauth: true, reAuthType: "99" });
+  clearAllSecondFactors();
+  const err = await loginHebau({ username: "2021010101", password: "pw" }).catch((e) => e);
+  assert.ok(!(err instanceof SecondFactorRequiredError));
+  assert.match((err as Error).message, /暂不支持/);
+  assert.equal(calls.filter((c) => c.includes("getDynamicCodeByReauth")).length, 0);
+});
+
+test("认证成功但拿不到教务会话时报错，不带空 Cookie 去抓数据", async () => {
+  installCas({ noSession: true });
+  await assert.rejects(
+    () => loginHebau({ username: "2021010101", password: "pw" }),
+    /未拿到教务系统会话/,
+  );
+});
+
+test("待验证会话超过 10 分钟即失效", async () => {
+  installCas({ reauth: true });
+  clearAllSecondFactors();
+  const err: SecondFactorRequiredError = await loginHebau({
+    username: "2021010101",
+    password: "pw",
+  }).catch((e) => e);
+  const file = path.join(process.env.RAPTOR_DATA_DIR ?? "", "school-mfa.json");
+  const store = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, { createdAt: number }>;
+  store[err.challengeId].createdAt -= 11 * 60 * 1000;
+  fs.writeFileSync(file, JSON.stringify(store));
+  assert.equal(findSecondFactor("hebau", "2021010101"), null);
+  assert.equal(typeof readSecondFactor(err.challengeId, "hebau", "2021010101"), "string");
+});


### PR DESCRIPTION
把 feat/hebau-school-adapter 合入 main：新增学校适配器层（registry/probe/types）+ 河北农大 URP 抓取（课表/成绩/考试/CAS/MFA），南工大逻辑收敛为默认适配器。本地验证：typecheck 通过，全量 250 测试通过。